### PR TITLE
use setuptools and add tests

### DIFF
--- a/kelle_test.py
+++ b/kelle_test.py
@@ -1,5 +1,0 @@
-import numpy as np
-from pyspextool.mc_bitset import bitset
-
-
-mask = bitset(np.array([3,4,1]),[0])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "pyspextool"
+version = "0.0.1"
+# dependencies = [
+#    "requests",
+#    'importlib-metadata; python_version<"3.8"',
+#]
+
+[tool.pytest.ini_options]
+pythonpath = [
+  "."
+]

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,25 @@
+from pyspextool.calibration import *
+from pyspextool.fit import *
+from pyspextool.io import *
+from pyspextool.plotting import *
+from pyspextool.uspex import *
+
+
+def test_calibration():
+    assert 1 == 1
+
+
+def test_fit():
+    assert 1 == 1
+
+
+def test_io():
+    assert 1 == 1
+
+
+def test_plotting():
+    assert 1 == 1
+
+
+def test_uspex():
+    assert 1 == 1


### PR DESCRIPTION
- adds a 'pyproject.toml' file so that we use 'setuptools' for packaging. https://setuptools.pypa.io/en/latest/userguide/quickstart.html
- adds a `tests/` directory and some placeholder tests.

`pytest` passes locally on my machine.