### PR TITLE
Edits to fix #94.

### DIFF
--- a/src/pyspextool/config.py
+++ b/src/pyspextool/config.py
@@ -10,6 +10,7 @@ state = {
     "lincormax": 0,
     "linearity_info": 0,
     "nint": 4,
+    "overwrite":True,
     "package_path": "",
     "proc_path": "",
     "pyspextool_keywords": "",

--- a/src/pyspextool/extract/config.py
+++ b/src/pyspextool/extract/config.py
@@ -88,8 +88,8 @@ parameters = {'apradii':1, 'psfradius':1, 'bgradius':1, 'bgwidth':1,
               'bgregions':1, 'bgdeg':1, 'qaplot':False, 'qafile':False,
               'qaplotsize':(6,10)}
 
-extract = {'verbose':True, 'qaplot':False, 'qafile':False, 'qaplotsize':(10,6),
-           'fix_bad_pixels':True, 'use_mean_profile':False}
+extract = {'verbose':True, 'overwrite':True, 'qaplot':False, 'qafile':False,
+           'qaplotsize':(10,6), 'fix_bad_pixels':True, 'use_mean_profile':False}
 
 combine = {'linearity_correction':True, 'beam_mode':1, 'scale_orders':False,
            'background_subtraction':False, 'flat_field_name':None,

--- a/src/pyspextool/extract/do_all_steps.py
+++ b/src/pyspextool/extract/do_all_steps.py
@@ -14,7 +14,7 @@ from pyspextool.extract.define_aperture_parameters import define_aperture_parame
 from pyspextool.extract.extract_apertures import extract_apertures
 
 
-def do_all_steps(files, verbose=None):
+def do_all_steps(files, verbose=None, overwrite=None):
     """
     To extract spectra from images in a loop after parameters are set.
 
@@ -31,6 +31,13 @@ def do_all_steps(files, verbose=None):
     verbose : {None, True, False}, optional
         Set to True/False to override config.state['verbose'] in the 
         pyspextool config file.  
+
+    overwrite : {None, True, False}, optional
+        Set to True/False to override config.state['overwrite'] in the
+        pyspextool config file.  
+        overwrite = True: FITS files will be overwritten.
+        overwrite = False: FITS files will not be overwritten but no OSError 
+        will be thrown. 
 
     Returns 
     -------
@@ -56,11 +63,14 @@ def do_all_steps(files, verbose=None):
 
     check_parameter('do_all_steps', 'files', files, ['str', 'list'])
 
-    check_parameter('do_all_steps', 'verbose', verbose, ['NoneType','bool'])    
+    check_parameter('do_all_steps', 'verbose', verbose, ['NoneType','bool'])
 
+    check_parameter('do_all_steps', 'ovewrite', overwrite, ['NoneType','bool'])
+    
 
     #
-    # Check the qa and verbose variables and set to system default if need be.
+    # Check the qa, verbose, overwrite variables and set to system default if
+    # need be.
     #
 
     if verbose is None:
@@ -73,6 +83,9 @@ def do_all_steps(files, verbose=None):
     elif verbose is False:
         logging.getLogger().setLevel(logging.ERROR)
         setup.state["verbose"] = False
+
+    if overwrite is None:
+        overwrite = setup.state['overwrite']        
     
     #
     # Figure out how many files we are talking about
@@ -213,7 +226,8 @@ def do_all_steps(files, verbose=None):
         # Extract apertures
         #
 
-        filenames = extract_apertures(verbose=extract.extract['verbose'])
+        filenames = extract_apertures(verbose=extract.extract['verbose'],
+                                      overwrite=overwrite)
         
         #
         # Store the successful file names

--- a/src/pyspextool/extract/extract_apertures.py
+++ b/src/pyspextool/extract/extract_apertures.py
@@ -1,5 +1,6 @@
 import numpy as np
 import os
+import logging
 
 from pyspextool import config as setup
 from pyspextool.extract import config as extract
@@ -13,7 +14,7 @@ from pyspextool.plot.plot_spectra import plot_spectra
 def extract_apertures(qa_show=None, qa_showsize=(10, 6), qa_write=None,
                       fix_bad_pixels=True, use_mean_profile=False,
                       bad_pixel_thresh=extract.state['bad_pixel_thresh'],
-                      verbose=None):
+                      verbose=None, overwrite=None):
     
     """
     User function to extract spectra.
@@ -37,6 +38,13 @@ def extract_apertures(qa_show=None, qa_showsize=(10, 6), qa_write=None,
     verbose : {None, True, False}, optional
         Set to True/False to override config.state['verbose'] in the
         pyspextool config file.
+
+    overwrite : {None, True, False}, optional
+        Set to True/False to override config.state['overwrite'] in the
+        pyspextool config file.  
+        overwrite = True: FITS files will be overwritten.
+        overwrite = False: FITS files will not be overwritten but no OSError 
+        will be thrown. 
 
     fix_bad_pixels : {True, False}, optional
         Set to True to fix bad pixels using the 2D model profiles.  
@@ -68,23 +76,23 @@ def extract_apertures(qa_show=None, qa_showsize=(10, 6), qa_write=None,
     check_parameter('extract_apertures', 'qa_show', qa_show,
                     ['NoneType', 'bool'])
 
-    check_parameter('extract_apertures', 'qa_showsize', qa_showsize,
-                    'tuple')
+    check_parameter('extract_apertures', 'qa_showsize', qa_showsize, 'tuple')
 
     check_parameter('extract_apertures', 'qa_write', qa_write,
                     ['NoneType', 'bool'])
 
-    check_parameter('extract_apertures', 'fix_bad_pixels',
-                    fix_bad_pixels, 'bool')
+    check_parameter('extract_apertures', 'fix_bad_pixels', fix_bad_pixels,
+                    'bool')
 
-    check_parameter('extract_apertures', 'use_mean_profile',
-                    use_mean_profile, 'bool')        
+    check_parameter('extract_apertures', 'use_mean_profile', use_mean_profile,
+                    'bool')        
     
-    check_parameter('extract_apertures', 'verbose',
-                    verbose, ['NoneType', 'bool'])
+    check_parameter('extract_apertures', 'verbose', verbose,
+                    ['NoneType', 'bool'])
 
     #
-    # Check the qa and verbose variables and set to system default if need be.
+    # Check the qa, verbose, overwrite variables and set to system default
+    # if need be.
     #
 
     if qa_write is None:
@@ -96,6 +104,15 @@ def extract_apertures(qa_show=None, qa_showsize=(10, 6), qa_write=None,
     if verbose is None:
         verbose = setup.state['verbose']
 
+    if verbose is True:
+        logging.getLogger().setLevel(logging.INFO)
+        
+    elif verbose is False:
+        logging.getLogger().setLevel(logging.ERROR)
+
+    if overwrite is None:
+        overwrite = setup.state['overwrite']
+
     #
     # Store user inputs
     #
@@ -103,6 +120,7 @@ def extract_apertures(qa_show=None, qa_showsize=(10, 6), qa_write=None,
     extract.extract['qafile'] = qa_write
     extract.extract['qaplot'] = qa_show
     extract.extract['verbose'] = verbose
+    extract.extract['overwrite'] = overwrite    
     extract.extract['fix_bad_pixels'] = fix_bad_pixels
     extract.extract['use_mean_profile'] = use_mean_profile
 
@@ -238,7 +256,7 @@ def extract_apertures(qa_show=None, qa_showsize=(10, 6), qa_write=None,
                                 optimal_info=optimalinfo,
                                 badpixel_info=badpixelinfo, qa_write=qa_write,
                                 qa_show=qa_show, qa_showsize=qa_showsize,
-                                verbose=verbose)
+                                verbose=verbose, overwrite=overwrite)
     
     #
     # Set the done variable
@@ -255,7 +273,7 @@ def extract_apertures(qa_show=None, qa_showsize=(10, 6), qa_write=None,
 
 def write_apertures(spectra, psbginfo=None, xsbginfo=None, optimal_info=None,
                     badpixel_info=None, qa_show=None, qa_write=None,
-                    qa_showsize=(10, 6), verbose=None):
+                    qa_showsize=(10, 6), verbose=True, overwrite=True):
 
     """
     To write extracted spectra to disk.
@@ -297,9 +315,13 @@ def write_apertures(spectra, psbginfo=None, xsbginfo=None, optimal_info=None,
         pyspextool config file.  If set to True, quality assurance
         plots will be written to disk.
 
-    verbose : {None, True, False}, optional
-        Set to True/False to override config.state['verbose'] in the
-        pyspextool config file.
+    verbose : {True, False}, optional
+        Set to True to report to the command line. 
+
+    overwrite : {True, False}, optional
+        overwrite = True: FITS files will be overwritten.
+        overwrite = False: FITS files will not be overwritten but no OSError 
+        will be thrown. 
 
     Returns 
     -------
@@ -378,7 +400,7 @@ def write_apertures(spectra, psbginfo=None, xsbginfo=None, optimal_info=None,
                                  psbginfo=psbginfo,
                                  optimal_info=optimal_info,
                                  badpixel_info=badpixel_info,
-                                 verbose=verbose)
+                                 verbose=verbose, overwrite=overwrite)
 
             # Plot the spectra
 
@@ -445,7 +467,7 @@ def write_apertures(spectra, psbginfo=None, xsbginfo=None, optimal_info=None,
                                      psbginfo=psbginfo,
                                      optimal_info=optimal_info,
                                      badpixel_info=badpixel_info,
-                                     verbose=verbose)
+                                     verbose=verbose, overwrite=overwrite)
 
                 # Plot the spectra
 
@@ -507,7 +529,7 @@ def write_apertures(spectra, psbginfo=None, xsbginfo=None, optimal_info=None,
                                      output_fullpath,
                                      wavecalinfo=wavecalinfo,
                                      psbginfo=psbginfo,
-                                     verbose=verbose)
+                                     verbose=verbose, overwrite=overwrite)
 
                 # Plot the spectra
 
@@ -576,7 +598,7 @@ def write_apertures(spectra, psbginfo=None, xsbginfo=None, optimal_info=None,
                                  output_fullpath, wavecalinfo=wavecalinfo,
 #                                 background_spectra=background[z],
                                  xsbginfo=xsbginfo,
-                                 verbose=verbose)
+                                 verbose=verbose, overwrite=overwrite)
 
             # Plot the spectra
 
@@ -613,7 +635,7 @@ def write_apertures(spectra, psbginfo=None, xsbginfo=None, optimal_info=None,
                                  output_fullpath, wavecalinfo=wavecalinfo,
 #                                 background_spectra=background[z],
                                  xsbginfo=xsbginfo,
-                                 verbose=verbose)
+                                 verbose=verbose, overwrite=overwrite)
 
             # Plot the spectra
 

--- a/src/pyspextool/extract/extract_extendedsource_1dxd.py
+++ b/src/pyspextool/extract/extract_extendedsource_1dxd.py
@@ -1,4 +1,5 @@
 import numpy as np
+import logging
 
 from pyspextool.extract.make_aperture_mask import make_aperture_mask
 from pyspextool.fit.polyfit import poly_fit_1d
@@ -131,13 +132,13 @@ def extract_extendedsource_1dxd(img, var, ordermask, orders, wavecal, spatcal,
 
         if verbose is True and i == 0:
 
-            message = 'Extracting ' + str(naps) + ' apertures in ' + str(norders) + \
+            message = ' Extracting ' + str(naps) + ' apertures in ' + str(norders) + \
                       ' orders'
 
             if bgregions is not None:
-                print(message + ' (with background subtraction)...')
+                logging.info(message + ' (with background subtraction)...')
             else:
-                print(message + ' (without background subtraction)...')
+                logging.info(message + ' (without background subtraction)...')
 
         zordr = np.where(ordermask == orders[i])
         xmin = np.min(xx[zordr])

--- a/src/pyspextool/io/write_apertures_fits.py
+++ b/src/pyspextool/io/write_apertures_fits.py
@@ -1,6 +1,7 @@
 import os
 from astropy.io import fits
 import numpy as np
+import logging
 
 from pyspextool.io.check import check_parameter
 from pyspextool.utils.split_text import split_text
@@ -108,6 +109,16 @@ def write_apertures_fits(spectra, xranges, aimage, sky, flat, naps, orders,
     check_parameter('write_apertures_fits', 'verbose', verbose,
                     'bool')
 
+    #
+    # Deal with logging
+    #
+    
+    if verbose is True:
+        logging.getLogger().setLevel(logging.INFO)
+        
+    elif verbose is False:
+        logging.getLogger().setLevel(logging.ERROR)
+    
     #    
     # Get set up
     #
@@ -308,22 +319,20 @@ def write_apertures_fits(spectra, xranges, aimage, sky, flat, naps, orders,
 
     hdr['FILENAME'] = (os.path.basename(output_fullpath)+'.fits', ' File name')
 
-    fits.writeto(output_fullpath + '.fits', array, hdr, overwrite=overwrite)
+    try:
+    
+        fits.writeto(output_fullpath + '.fits', array, hdr, overwrite=overwrite)
+        message = ' Wrote file '+os.path.basename(output_fullpath)+\
+                  '.fits to disk.'
+        logging.info(message)
 
-    #
-    # Update the user
-    #
+    except OSError as e:
 
-    if verbose is True:
-
-        if xsbginfo is None:
-            print('Wrote', os.path.basename(output_fullpath)+'.fits',
-                  'to disk.')
-
-        if xsbginfo is not None:
-            print('Wrote', os.path.basename(output_fullpath)+'.fits', 'and',
-                  os.path.basename(output_fullpath)+'.fits', 'to disk.')
-
+            message = f"\n\n\nEncountered error `{e}` in "+\
+              "io.write_apertures_fits.  \n\nNo file written to disk.\n\n\n"
+            
+            logging.error(message)        
+        
     #
     # Return the file name written to disk
     #

--- a/src/pyspextool/setup_utils.py
+++ b/src/pyspextool/setup_utils.py
@@ -18,6 +18,7 @@ def pyspextool_setup(
     cal_path: str = None,
     proc_path: str = None,
     verbose: bool = False,
+    overwrite: bool = True, 
     qa_show: bool = None,
     qa_write: bool = None,
     qa_path: str = None,
@@ -51,6 +52,11 @@ def pyspextool_setup(
             Lots of information will be printed to the screen.
         verbose = False sets the logging level to INFO
             Only important information will be printed to the screen.
+
+    overwrite : bool, default = True
+        overwrite = True.  Will overwrite FITS images.
+        overwrite = False.  Will not overwrite FITS images but also not 
+        throw an OSError.
 
     qa_show : {True, False}, optional
         True: Display the quality assurance plots to the screen.
@@ -86,8 +92,13 @@ def pyspextool_setup(
     elif verbose is False:
         logging.getLogger().setLevel(logging.ERROR)
         setup.state["verbose"] = False
-
+            
     logging.info(f"Verbose set to {setup.state['verbose']}")
+
+    # Set overwrite
+
+    setup.state["overwrite"] = overwrite
+
     # Set the instrument
 
     if instrument is not None:

--- a/src/pyspextool/telluric/telluric_correction.py
+++ b/src/pyspextool/telluric/telluric_correction.py
@@ -37,7 +37,7 @@ def telluric_correction(object_file:str, standard:str, standard_file:str,
                         qa_showsize:tuple=(10, 6),
                         qa_write:typing.Optional[bool]=None,
                         verbose:typing.Optional[bool]=None,
-                        overwrite:bool=True):
+                        overwrite:bool=None):
 
     """
     To correct spectra for telluric absorption and flux calibrate
@@ -152,7 +152,8 @@ def telluric_correction(object_file:str, standard:str, standard_file:str,
 
     check_parameter('basic_tellcor', 'verbose', verbose, ['NoneType', 'bool'])
 
-    check_parameter('basic_tellcor', 'overwrite', overwrite, 'bool')    
+    check_parameter('basic_tellcor', 'overwrite', overwrite,
+                    ['NoneType','bool'])    
 
     #
     # Check the qa and verbose variables and set to system default if need be.
@@ -177,6 +178,9 @@ def telluric_correction(object_file:str, standard:str, standard_file:str,
         logging.getLogger().setLevel(logging.ERROR)
         setup.state["verbose"] = False
 
+    if overwrite is None:
+        overwrite = setup.state['overwrite']
+        
 
     # Get user paths if need be.
         
@@ -454,9 +458,21 @@ def telluric_correction(object_file:str, standard:str, standard_file:str,
         hdr['HISTORY'] = hist
 
     output_fullpath = os.path.join(output_path, output_name+'.fits')
-    
-    fits.writeto(output_fullpath, object_spectra, hdr, overwrite=overwrite)
 
+    try:
+    
+        fits.writeto(output_fullpath, object_spectra, hdr, overwrite=overwrite)
+        message = ' Wrote file '+os.path.basename(output_fullpath)+' to disk.'
+        logging.info(message)
+
+    except OSError as e:
+
+        message = f"\n\n\nEncountered error `{e}` in "+\
+              "telluric.telluric_correction.  \n\n"+\
+              "No file written to disk.\n\n\n"
+            
+        logging.error(message)
+        
     #
     # Plot the results
     #
@@ -481,8 +497,6 @@ def telluric_correction(object_file:str, standard:str, standard_file:str,
     # Update the user
     #
 
-    message = ' Wrote '+os.path.basename(output_fullpath)+' to disk.'
-    logging.info(message)
 
 
 def get_modeinfo(mode):

--- a/src/pyspextool/utils/loop_progress.py
+++ b/src/pyspextool/utils/loop_progress.py
@@ -1,3 +1,5 @@
+import logging
+
 def loop_progress(idx, bot, top, message=None):
 
     """
@@ -21,27 +23,21 @@ def loop_progress(idx, bot, top, message=None):
     --------
     None
 
-    Procedure
-    ---------
-    Just prints a updating message on the command line
-
     Example
     --------
     >>> loopprogress(i,0,100)
      90% |*************************************                       |
 
 
-    Modification History
-    --------------------
-    2022-05-25 - Written by M. Cushing, University of Toledo.
-                Based on the Spextool mc_loopprogress.pro IDL program.
     """
+
+    logging.getLogger().setLevel(logging.INFO)    
     
     # Print the message if necessary
     
     if idx == 0 and message is not None:
 
-        print(message)
+        logging.info(' '+message)
 
     # Run counter        
             


### PR DESCRIPTION
1) All programs that write FITS files to disk now have a overwrite keyword. 
2) ps.pyspextool_setup now has a overwrite keyword.  By default it is set to None which means it defaults to True (in the config.py file). 
3) Setting overwrite in ps.pyspextool_setup to False acts like verbose.  That is, all subsequent functions will be called with overwrite=False unless otherwise directed by the user. 
4) Setting to False no longer throws an OSError but simply tells the user the OSError was tripped, and that no file was written to disk. 
5) Updated logging statements in programs that didn't use it.