### PR TITLE
Module to convert spextool FITS to specutils FITS

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,5 +10,6 @@ dependencies:
   - pandas
   - pip
   - scipy
+  - specutils
   - pip:
     - git-lfs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "pandas",
     "importlib_resources; python_version < '3.9'",
     "git-lfs",
-    "astroquery"
+    "astroquery",
+    "specutils"
 ]
 
 [tool.setuptools]

--- a/src/pyspextool/io/convert_fits.py
+++ b/src/pyspextool/io/convert_fits.py
@@ -1,0 +1,150 @@
+from os.path import basename, join
+import logging
+import numpy as np
+from astropy.io import fits
+import astropy.units as u
+from specutils import Spectrum1D
+import matplotlib.pyplot as plt
+from astropy.table import Table
+from pyspextool.io.read_spectra_fits import read_spectra_fits
+
+__all__ = ["convert_to_fits", "spectrum_plottable"]
+
+logger = logging.getLogger("pyspextool")
+
+
+def spectrum_isplottable(spectrum_path, raise_error=True, show_plot=False):
+    """
+    Check if spectrum is plottable
+    """
+    # load the spectrum and make sure it's a Spectrum1D object
+
+    try:
+        # spectrum: Spectrum1D = load_spectrum(spectrum_path) #astrodbkit2 method
+        spectrum = Spectrum1D.read(spectrum_path)
+    except Exception as e:
+        msg = (
+            str(e) + f"\nSkipping {spectrum_path}: \n"
+            "unable to load file as Spectrum1D object"
+        )
+        if raise_error:
+            logger.error(msg)
+            raise IOError(msg)
+        else:
+            logger.warning(msg)
+            return False
+
+    # checking spectrum has good units and not only NaNs
+    try:
+        wave: np.ndarray = spectrum.spectral_axis.to(u.micron).value
+        flux: np.ndarray = spectrum.flux.value
+    except AttributeError as e:
+        msg = str(e) + f"Skipping {spectrum_path}: unable to parse spectral axis"
+        if raise_error:
+            logger.error(msg)
+            raise IOError(msg)
+        else:
+            logger.warning(msg)
+            return False
+    except u.UnitConversionError as e:
+        msg = (
+            e + f"Skipping {spectrum_path}: unable to convert spectral axis to microns"
+        )
+        if raise_error:
+            logger.error(msg)
+            raise IOError(msg)
+        else:
+            logger.warning(msg)
+            return False
+    except ValueError as e:
+        msg = e + f"Skipping {spectrum_path}: Value error"
+        if raise_error:
+            logger.error(msg)
+            raise IOError(msg)
+        else:
+            logger.warning(msg)
+            return False
+
+    # check for NaNs
+    nan_check: np.ndarray = ~np.isnan(flux) & ~np.isnan(wave)
+    wave = wave[nan_check]
+    flux = flux[nan_check]
+    if not len(wave):
+        msg = f"Skipping {spectrum_path}: spectrum is all NaNs"
+        if raise_error:
+            logger.error(msg)
+            raise IOError(msg)
+        else:
+            logger.warning(msg)
+            return False
+
+    if show_plot:
+        plt.plot(wave, flux)
+        plt.show()
+
+    return True
+
+
+def convert_to_fits(input_file, output_path="."):
+    """
+    Convert a pyspextool file to a specutils compatibile FITS file
+    TODO: write tests
+    TODO: think about header keywords and Spectrum DM 1.2
+
+    Parameters
+    ----------
+    input_file : str
+    output_path : str
+
+    Returns
+    -------
+    None
+
+    Writes converted FITS file to output_path
+
+    """
+
+    spectra, header_dict = read_spectra_fits(input_file)
+
+    wavelength = spectra[0, 0, :]
+    flux = spectra[0, 1, :]
+    flux_unc = spectra[0, 2, :]
+
+    # header = compile_header(wavelength, **spectrum_info_all)
+    header = header_dict["header"]
+    header["HISTORY"] = (
+        f"Converted {basename(input_file)} using pyspextool convert_to_fits.py function"
+    )
+    object_name = header["OBJECT"]
+    obs_date = header["AVE_DATE"]
+
+    x_units = header["XUNITS"]
+    y_units = header["YUNITS"]
+
+    spectrum_data_out = Table(
+        {
+            "wavelength": wavelength * u.Unit(x_units),
+            "flux": flux * u.Unit(y_units),
+            "flux_uncertainty": flux_unc * u.Unit(y_units),
+        }
+    )
+
+    # Make the HDUs
+    hdu1 = fits.BinTableHDU(data=spectrum_data_out)
+    hdu1.header["EXTNAME"] = "SPECTRUM"
+    hdu1.header.set("OBJECT", object_name, "Object Name")
+    hdu0 = fits.PrimaryHDU(header=header)
+
+    # Write the MEF with the header and the data
+    spectrum_mef = fits.HDUList([hdu0, hdu1])  # hdu0 is header and hdu1 is data
+
+    fits_filename = f"{object_name}_{obs_date}.fits"
+    fits_path = join(output_path, fits_filename)
+    try:
+        spectrum_mef.writeto(fits_path, overwrite=True, output_verify="exception")
+        # TODO: think about overwrite
+        logger.info(f"Wrote {fits_path}")
+    except:
+        raise
+
+    return

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,5 +1,7 @@
+from os.path import join
 from pyspextool.io import files
-from pyspextool.io.files import *
+from pyspextool.io.files import check_file, extract_filestring, make_full_path
+from pyspextool.io.convert_fits import convert_to_fits, spectrum_isplottable
 import pytest
 from os.path import exists
 
@@ -7,9 +9,9 @@ from os.path import exists
 def test_check_file():
 
     result = check_file(files.__file__)
-    assert exists(result) == True
+    assert exists(result) is True
 
-    with pytest.raises(ValueError) as info:
+    with pytest.raises(ValueError):
         result = check_file(files.__file__+'a')
 
 
@@ -24,12 +26,11 @@ def test_extract_filestring():
     assert result == ['spec1.fits', 'spec2.fits']
 
     files = 'spec1.fits,spec2.fits'
-    with pytest.raises(ValueError) as info:
+    with pytest.raises(ValueError):
         result = extract_filestring(files, 'filenames')
-    
+
 
 def test_make_full_path():
-
     files = '1-5'
     dir = '../data/'
     result = make_full_path(dir, files, indexinfo={'nint': 5,
@@ -41,3 +42,59 @@ def test_make_full_path():
                       '../data/spc-00003.[ab].fits',
                       '../data/spc-00004.[ab].fits',
                       '../data/spc-00005.[ab].fits']
+
+
+@pytest.mark.parametrize(
+    "file,output_path,out_file",
+    [
+        (
+            "tests/test_data/spex-SXD/proc/combspec626-635.fits",
+            "tests/test_data/spex-SXD/proc/",
+            "HD_160365_2003Jul07.fits",
+        ),
+        (
+            "tests/test_data/spex-SXD/proc/combspec636-645.fits",
+            "tests/test_data/spex-SXD/proc/",
+            "HD_165029_2003Jul07.fits",
+        ),
+        (
+            "tests/test_data/uspex-prism/proc/combspec1-2.fits",
+            "tests/test_data/uspex-prism/proc/",
+            "2010-1707_2022Oct19.fits",
+        ),
+        (
+            "tests/test_data/uspex-prism/proc/combspec7-8.fits",
+            "tests/test_data/uspex-prism/proc/",
+            "HD_193689_2022Oct19.fits",
+        ),
+        (
+            "tests/test_data/uspex-SXD/proc/combspec1-8.fits",
+            "tests/test_data/uspex-SXD/proc/",
+            "HD100906_G9w+_2015Jun03.fits",
+        ),
+        (
+            "tests/test_data/uspex-SXD/proc/combspec11-18.fits",
+            "tests/test_data/uspex-SXD/proc/",
+            "HD101369_A0V_2015Jun03.fits",
+        ),
+    ],
+)
+def test_convert_to_fits(file, output_path, out_file):
+    convert_to_fits(file, output_path=output_path)
+    assert exists(join(output_path, out_file)) is True
+
+
+@pytest.mark.parametrize(
+    "file",
+    [
+        "tests/test_data/spex-SXD/proc/HD_160365_2003Jul07.fits",
+        "tests/test_data/spex-SXD/proc/HD_165029_2003Jul07.fits",
+        "tests/test_data/uspex-prism/proc/2010-1707_2022Oct19.fits",
+        "tests/test_data/uspex-prism/proc/HD_193689_2022Oct19.fits",
+        "tests/test_data/uspex-SXD/proc/HD100906_G9w+_2015Jun03.fits",
+        "tests/test_data/uspex-SXD/proc/HD101369_A0V_2015Jun03.fits",
+    ],
+)
+def test_spectrum_isplottable(file):
+    result = spectrum_isplottable(file, raise_error=True, show_plot=False)
+    assert result is True


### PR DESCRIPTION
- `convert_fits`: reads in a spextool FITS file and writes out a FITS file which can be read by `specutils` into a Spectrum1D object without specifying a reader.
- `spectrum_isplottable`: tests if a FITS file is readable by `specutils` into a Spectrum1D object without specifying a reader. and other things to make sure it's a usable/plottable spectrum.

Closes #144 

TODO:
- [x] write some tests

Example:
```python
from os.path import join
from pyspextool.io.convert_fits import convert_to_fits, spectrum_isplottable

test_file = "/Users/kelle/Desktop/processed data set/calspec41-58.fits"
out_path = "/Users/kelle/Desktop/processed data set/converted/"
convert_to_fits(test_file, output_path=out_path)

new_file = join(out_path, "TOI1278_2020-12-24.fits")

spectrum_isplottable(new_file, raise_error=True, show_plot=True)


