### PR TITLE
Add Astropy functions to tests

### DIFF
--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -2,24 +2,26 @@ import numpy as np
 from pyspextool.utils.coords import ten, sixty
 import math 
 import pytest
-from astropy.coordinates import SkyCoord
+from astropy.coordinates import Angle
 import astropy.units as u
 
-@pytest.mark.parametrize('value,expected', 
+@pytest.mark.parametrize('input_ten, input_angle,expected', 
     [
-        ('-00:00:40.04424',-0.0111234), # ten('-00:00:40.04424')
-        ([-0.0,0.0,40.04424],-0.0111234), # ten([-0.0,0.0,40.04424])
-        ([0.0,0.0,-40.04424],-0.0111234), # ten([0.0,0.0,-40.04424])
-        (np.array([-0.0,0.0,40.04424]), -0.0111234), # ten(np.array([-0.0,0.0,40.04424]))
-        (np.array([0.0,0.0,-40.04424]), -0.0111234)  #ten(np.array([0.0,0.0,-40.04424]))
+        ('-00:00:40.04424', '-00:00:40.04424',-0.0111234), # ten('-00:00:40.04424')
+        ([-0.0,0.0,41.04424], '-0 0 41.04424',-0.011401178), # ten([-0.0,0.0,40.04424])
+        ([0.0,0.0,-42.04424], '-42.04424s', -0.011678955556), # ten([0.0,0.0,-40.04424])
+        (np.array([-0.0,0.0,43.04424]), '-0 0 43.04424', -0.0119567334), # ten(np.array([-0.0,0.0,40.04424]))
+        (np.array([0.0,0.0,-44.04424]), "-44.04424″", -0.012234511)  #ten(np.array([0.0,0.0,-40.04424]))
     ])
-def test_ten(value, expected):
-    result = ten(value)
-    assert math.isclose(result,expected)
+def test_ten(input_ten, input_angle,expected):
+    result = ten(input_ten)
+    assert np.isclose(result,expected)
+    print('ten', result)
 
-    c = SkyCoord(ra=1, dec=value, unit=('hourangle', 'deg'))
-    assert math.isclose(c.dec.value,expected), f"dec provided: {value}, dec returned: {c.dec}"
-    assert c.dec.unit.is_equivalent(u.degree)
+    angle = Angle(input_angle, unit=u.deg)
+    print('angle', angle)    
+    assert np.isclose(angle.value, expected), f"angle provided: {input_angle}, angle returned: {angle}"
+    assert angle.unit.is_equivalent(u.degree)
 
 def test_sixty():
 

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -23,26 +23,22 @@ def test_ten(input_ten, input_angle,expected):
     assert np.isclose(angle.value, expected), f"angle provided: {input_angle}, angle returned: {angle}"
     assert angle.unit.is_equivalent(u.degree)
 
-def test_sixty():
+@pytest.mark.parametrize('input_sixty, output_sixty,plus, trailsign,expected',
+    [
+        (-0.0111234, [0,0,-40.04424], 0, False, '-00:00:40.04'),
+        (-0.0111234, [-0,0,40.04424], 1, True, '-00:00:40.04'),
+        (0.0111234, [0,0,40.04424], 0, False,'00:00:40.04'),
+        (0.0111234, [0,0,40.04424], 1, True,'+00:00:40.04')
 
-    result = sixty(-0.0111234)
-    np.testing.assert_array_equal(result,[0,0,-40.04424])
+    ])
+def test_sixty(input_sixty, output_sixty, plus, trailsign, expected):
 
-    result = sixty(-0.0111234,trailsign=True)
-    np.testing.assert_array_equal(result,[-0,0,40.04424])
+    result = sixty(input_sixty, trailsign=trailsign)
+    np.testing.assert_array_equal(result,output_sixty)
 
-    result = sixty(-0.0111234, colons={'dec':2,'plus':1}, trailsign=True)
-    assert result == '-00:00:40.04'
+    result = sixty(input_sixty, colons={'dec':2,'plus':plus}, trailsign=trailsign)
+    assert result == expected
 
-    result = sixty(0.0111234)
-    np.testing.assert_array_equal(result,[0,0,40.04424])
-
-    result = sixty(0.0111234,trailsign=True)
-    np.testing.assert_array_equal(result,[0,0,40.04424])
-
-    result = sixty(0.0111234, colons={'dec':3,'plus':0}, trailsign=True)
-    assert result == '00:00:40.044'
-
-    result = sixty(0.0111234, colons={'dec':2,'plus':1}, trailsign=True)
-    assert result == '+00:00:40.04'        
-    
+    angle = Angle(input_sixty, unit=u.deg)
+    angle_string = angle.to_string(unit=u.degree, sep=':', alwayssign=trailsign,pad=True, precision=2)      
+    assert angle_string == expected

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -1,23 +1,25 @@
 import numpy as np
-from pyspextool.utils.coords import *
+from pyspextool.utils.coords import ten, sixty
 import math 
+import pytest
+from astropy.coordinates import SkyCoord
+import astropy.units as u
 
-def test_ten():
+@pytest.mark.parametrize('value,expected', 
+    [
+        ('-00:00:40.04424',-0.0111234), # ten('-00:00:40.04424')
+        ([-0.0,0.0,40.04424],-0.0111234), # ten([-0.0,0.0,40.04424])
+        ([0.0,0.0,-40.04424],-0.0111234), # ten([0.0,0.0,-40.04424])
+        (np.array([-0.0,0.0,40.04424]), -0.0111234), # ten(np.array([-0.0,0.0,40.04424]))
+        (np.array([0.0,0.0,-40.04424]), -0.0111234)  #ten(np.array([0.0,0.0,-40.04424]))
+    ])
+def test_ten(value, expected):
+    result = ten(value)
+    assert math.isclose(result,expected)
 
-    result = ten('-00:00:40.04424')
-    assert math.isclose(result,-0.0111234)
-
-    result = ten([-0.0,0.0,40.04424])
-    assert math.isclose(result,-0.0111234)
-
-    result = ten([0.0,0.0,-40.04424])
-    assert math.isclose(result,-0.0111234)
-
-    result = ten(np.array([-0.0,0.0,40.04424]))
-    assert math.isclose(result,-0.0111234)
-
-    result = ten(np.array([0.0,0.0,-40.04424]))
-    assert math.isclose(result,-0.0111234)
+    c = SkyCoord(ra=1, dec=value, unit=('hourangle', 'deg'))
+    assert math.isclose(c.dec.value,expected), f"dec provided: {value}, dec returned: {c.dec}"
+    assert c.dec.unit.is_equivalent(u.degree)
 
 def test_sixty():
 

--- a/tests/test_irplanck.py
+++ b/tests/test_irplanck.py
@@ -1,8 +1,19 @@
 import numpy as np
-from unittest import TestCase
 from pyspextool.utils.irplanck import irplanck
+from astropy.modeling.models import BlackBody
+import astropy.units as u
 
+def test_irplank():
+    # 1.2 microns, 6000 K
+    value = irplanck(1.2, 6000)
 
-value = irplanck(1.2,6000)
+    # 1.2 microns, 6000 K, RETURS 7506318  W m-2 um-1 sr-1
+    np.testing.assert_allclose(value, 7506318.497767141, 0.001)
 
-np.testing.assert_allclose(value,7506318.497767141,0.001)
+    wavelength = 1.2 * u.micron
+    temperature = 6000 * u.K
+    scale = 1 * u.W / (u.m**2 * u.um * u.sr)
+
+    bb = BlackBody(temperature=temperature, scale=scale)
+    bb_result = bb(wavelength)
+    np.testing.assert_allclose(bb_result.value, 7506318., 0.001)


### PR DESCRIPTION
Tests which demonstrate relevant Astropy functions to replace `irplank`, `ten` and `sixty`.