### PR TITLE
Move big files to AWS

### DIFF
--- a/src/pyspextool/instruments/spex/spex.py
+++ b/src/pyspextool/instruments/spex/spex.py
@@ -4,6 +4,7 @@ from astropy.io import fits
 from astropy.time import Time
 import re
 import os
+import sys
 
 from pyspextool import config as setup
 from pyspextool.fit.polyfit import image_poly
@@ -11,7 +12,6 @@ from pyspextool.io.check import check_parameter
 from pyspextool.io.fitsheader import get_headerinfo
 from pyspextool.utils.arrays import idl_rotate
 from pyspextool.utils import math
-from pyspextool.utils.split_text import split_text
 from pyspextool.utils.loop_progress import loop_progress
 
 
@@ -485,7 +485,10 @@ def read_fits(files,
 
         linearity_file = os.path.join(setup.state['instrument_path'],
                                       'spex_lincorr.fits')
-        linearity_coeffs = fits.getdata(linearity_file)
+        try:
+            linearity_coeffs = fits.getdata(linearity_file)
+        except FileNotFoundError:
+            linearity_coeffs = fits.getdata("https://pyspextool.s3.us-east-1.amazonaws.com/spex_lincorr.fits")
 
     else:
 
@@ -603,5 +606,3 @@ def spex_linearity_imagepoly(image, coefficients):
     result = image_poly(corrected_image, coefficients)
 
     return result
-
-

--- a/src/pyspextool/instruments/spex/spex_lincorr.fits
+++ b/src/pyspextool/instruments/spex/spex_lincorr.fits
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:47fcbd6b854f1b80fc65615978dffdcfa793af24d12b3ce3b199efae6d78040f
-size 16781760

--- a/src/pyspextool/instruments/uspex/uspex.py
+++ b/src/pyspextool/instruments/uspex/uspex.py
@@ -171,7 +171,11 @@ def read_fits(files:list,
 
     bias_file = join(setup.state['instrument_path'],'uspex_bias.fits')
     
-    hdul = fits.open(bias_file)
+    try:
+        hdul = fits.open(bias_file)
+    except FileNotFoundError:  
+        hdul = fits.open("https://pyspextool.s3.us-east-1.amazonaws.com/uspex_bias.fits")
+    
     divisor = hdul[0].header['DIVISOR']
     bias = hdul[0].data / divisor
     hdul.close()

--- a/src/pyspextool/instruments/uspex/uspex_bias.fits
+++ b/src/pyspextool/instruments/uspex/uspex_bias.fits
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d1dbbffc882123de5f3e877ca14dbc6740e2e751d1c31d0647583305c6163cc6
-size 16787520


### PR DESCRIPTION
We can't put the package on PyPi with large files (#238 ).  This PR moves `uspex_bias.fits` and `spex_lincorr.fits` to AWS.