### PR TITLE
Remove unused atrans files

### DIFF
--- a/src/pyspextool/data/atran5000.fits
+++ b/src/pyspextool/data/atran5000.fits
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1b36edec11dca3e2676d155bd6658e096351fdb1924dd9e5dae30d35ba55bc0d
-size 2845440

--- a/src/pyspextool/data/atran6000.fits
+++ b/src/pyspextool/data/atran6000.fits
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3409283a19ad4784b379b5b3d0a2dfb42e22193aeee8b07ffb735e9e1bd72e2c
-size 2845440

--- a/src/pyspextool/data/atran60000.fits
+++ b/src/pyspextool/data/atran60000.fits
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:07fb23d9241ed77f2126b8968ba7ea0510a6b3317faa1e3888d71e384292689f
-size 6799680

--- a/src/pyspextool/data/atran75000.fits
+++ b/src/pyspextool/data/atran75000.fits
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:09259dfd4a3ae7535ad27e67d7817d562376277d9bc41e860e71f15edc9c42ba
-size 28163520


### PR DESCRIPTION
There are some big files which are not currently being used which can be deleted. Closes #262 .