### PR TITLE
fixes for issue 303 and 342

### DIFF
--- a/src/pyspextool/config.py
+++ b/src/pyspextool/config.py
@@ -1,10 +1,12 @@
 state = {"instruments": ['uspex', 'spex'],
          "qa_extensions": ['.png', '.pdf'],
-         "search_extensions": ['.fits*', '.fits','.fits.gz'],         
+         "input_suffixes": ['.fits*', '.fits','.fits.gz'],         
          "units":['W m-2 um-1', 'erg s-1 cm-2 A-1', 'W m-2 Hz-1',
                   'ergs s-1 cm-2 Hz-1', 'Jy', 'mJy', 'uJy'],
          "version": None,
          "telluric_correctiontypes":['A0 V', 'basic', 'reflectance'],
+         "reduction_modes":['A','A-B'],
+         "rectification_methods":['linear','cubic'],
          "vega_zmag":-0.03,
          "vega_zfd":3.46e-9*10, # ergs s-1 cm-2 A-1
          "vega_zlambda":5556e-4, # microns

--- a/src/pyspextool/extract/combine_images.py
+++ b/src/pyspextool/extract/combine_images.py
@@ -5,41 +5,39 @@ from astropy.io import fits
 import logging
 
 from pyspextool import config as setup
-from pyspextool.extract import config as extract
 
 from pyspextool.extract import background_subtraction as background
 from pyspextool.extract.images import scale_order_background
 from pyspextool.io.check import check_parameter, check_qakeywords, check_file
-from pyspextool.io.files import make_full_path
 from pyspextool.extract.flat import read_flat_fits
 from pyspextool.io.reorder_irtf_files import reorder_irtf_files
 from pyspextool.io.fitsheader import average_headerinfo
 from pyspextool.utils import math
 from pyspextool.utils.arrays import idl_unrotate
 from pyspextool.utils.split_text import split_text
-from pyspextool.utils.loop_progress import loop_progress
 from pyspextool.plot.plot_image import plot_image
 from pyspextool.io.files import files_to_fullpath
 from pyspextool.pyspextoolerror import pySpextoolError
 
 
-def combine_images(files:str | list,
-                   output_fileroot:str,
-                   input_extension:str='.fits*',
-                   output_directory:str='proc',
-                   correct_nonlinearity:bool=True,
-                   beam_mode:str='A',
-                   scale_background:bool=False,
-                   subtract_background:bool=False,
-                   flatfield_filename:str=None,
-                   flatfield:bool=False,
-                   statistic:str='robust weighted mean',
-                   robust_sigma:int | float=8,
-                   verbose=None,
-                   qa_show=None,
-                   qa_showscale:float | int=1.0,
-                   qa_showblock:bool=None,
-                   qa_write=None):
+def combine_images(
+    files:str | list,
+    output_fileroot:str,
+    input_extension:str='.fits*',
+    output_directory:str='proc',
+    correct_nonlinearity:bool=True,
+    beam_mode:str='A',
+    scale_background:bool=False,
+    subtract_background:bool=False,
+    flatfield_filename:str=None,
+    flatfield:bool=False,
+    statistic:str='robust weighted mean',
+    robust_sigma:int | float=8,
+    verbose=None,
+    qa_show=None,
+    qa_showscale:float | int=1.0,
+    qa_showblock:bool=None,
+    qa_write=None):
 
     """
     To combine (pair-subtracted) images for later extraction.
@@ -139,57 +137,64 @@ def combine_images(files:str | list,
     #  Check parameters and QA keywords
     #
 
-    check_parameter('combine_images', 'files', files, ['str', 'list'],
-                    list_types=['str','str'])
+    check_parameter('combine_images', 'files', 
+                    files, ['str', 'list'], list_types=['str','str'])
 
-    check_parameter('combine_images', 'output_fileroot', output_fileroot, 'str')
+    check_parameter('combine_images', 'output_fileroot', 
+                    output_fileroot, 'str')
 
-    check_parameter('combine_images', 'input_extension', input_extension, 'str')
+    check_parameter('combine_images', 'input_extension', 
+                    input_extension, 'str')
 
-    check_parameter('combine_images', 'output_directory', output_directory,
-                    'str', possible_values=['proc', 'cal'])
+    check_parameter('combine_images', 'output_directory', 
+                    output_directory, 'str', possible_values=['proc', 'cal'])
     
     check_parameter('combine_images', 'correct_nonlinearity',
                     correct_nonlinearity, 'bool')
 
-    check_parameter('combine_images', 'beam_mode', beam_mode, 'str',
-                    possible_values=['A', 'A-B'])
+    check_parameter('combine_images', 'beam_mode', 
+                    beam_mode, 'str', possible_values=['A', 'A-B'])
 
-    check_parameter('combine_images', 'scale_background', scale_background,
-                    'bool')
+    check_parameter('combine_images', 'scale_background', 
+                    scale_background, 'bool')
 
     check_parameter('combine_images', 'subtract_background',
                     subtract_background, 'bool')
 
-    check_parameter('combine_images', 'flatfield_fiename', flatfield_filename,
-                    ['NoneType', 'str'])
+    check_parameter('combine_images', 'flatfield_fiename', 
+                    flatfield_filename, ['NoneType', 'str'])
 
-    check_parameter('combine_images', 'flatfield', flatfield, 'bool')
+    check_parameter('combine_images', 'flatfield', 
+                    flatfield, 'bool')
 
-    check_parameter('combine_spectra', 'statistic', statistic, 'str')
+    check_parameter('combine_spectra', 'statistic', 
+                    statistic, 'str')
 
-    check_parameter('combine_spectra', 'robust_sigma', robust_sigma,
-                    ['int', 'float'])
+    check_parameter('combine_spectra', 'robust_sigma', 
+                    robust_sigma, ['int', 'float'])
 
-    check_parameter('combine_images', 'verbose', verbose, ['NoneType', 'bool'])
+    check_parameter('combine_images', 'verbose', 
+                    verbose, ['NoneType', 'bool'])
 
-    check_parameter('combine_images', 'qa_write', qa_write,
-                    ['NoneType', 'bool'])
+    check_parameter('combine_images', 'qa_write', 
+                    qa_write, ['NoneType', 'bool'])
 
-    check_parameter('combine_images', 'qa_show', qa_show, ['NoneType', 'bool'])
+    check_parameter('combine_images', 'qa_show', 
+                    qa_show, ['NoneType', 'bool'])
 
-    check_parameter('combine_images', 'qa_showscale', qa_showscale,
-                    ['int', 'float'])
+    check_parameter('combine_images', 'qa_showscale', 
+                    qa_showscale, ['int', 'float'])
 
-    check_parameter('combine_images', 'qa_showblock', qa_showblock,
-                    ['NoneType', 'bool'])
+    check_parameter('combine_images', 'qa_showblock', 
+                    qa_showblock, ['NoneType', 'bool'])
 
-    qa = check_qakeywords(verbose=verbose,
-                          show=qa_show,
-                          showscale=qa_showscale,
-                          showblock=qa_showblock,
-                          write=qa_write)
-
+    qa = check_qakeywords(
+        verbose=verbose,
+        show=qa_show,
+        showscale=qa_showscale,
+        showblock=qa_showblock,
+        write=qa_write)
+    
     #
     # Let the user know what you are doing.
     #
@@ -199,11 +204,12 @@ def combine_images(files:str | list,
 #
     # Create the file names
 
-    result = files_to_fullpath(setup.state['raw_path'],
-                               files,
-                               setup.state['nint'],
-                               setup.state['suffix'],
-                               input_extension)
+    result = files_to_fullpath(
+        setup.state['raw_path'],
+        files,
+        setup.state['nint'],
+        setup.state['suffix'],
+        input_extension)
     input_files = result[0]
     check_file(input_files)
 
@@ -258,12 +264,6 @@ def combine_images(files:str | list,
 
         flatinfo = read_flat_fits(file_name)
         rotation = flatinfo['rotation']
-        # edgecoeffs = flatinfo['edgecoeffs']
-        # xranges = flatinfo['xranges']
-        # orders = flatinfo['orders']
-        # ybuffer = flatinfo['ybuffer']
-
-
         unrotate = True
 
     else:
@@ -304,17 +304,14 @@ def combine_images(files:str | list,
 
             logging.info(' Scaling the orders to a common intensity level.')
 
-            result = scale_order_background(data,
-                                            flatinfo['orders'],
-                                            flatinfo['edgecoeffs'],
-                                            flatinfo['xranges'],
-            #                                 orders,
-            #                                 edgecoeffs,
-            #                                 xranges,
-                                            var_stack=var,
-                                            ybuffer=ybuffer,
-                                            verbose=qa['verbose'])
-
+            result = scale_order_background(
+                data,
+                flatinfo['orders'],
+                flatinfo['edgecoeffs'],
+                flatinfo['xranges'],
+                var_stack=var,
+                ybuffer=flatinfo['ybuffer'],
+                verbose=qa['verbose'])
 
             data = result[0]
             var = result[1]
@@ -329,11 +326,13 @@ def combine_images(files:str | list,
         
         for i in range(nimages):
             
-            result = background.median_1dxd(data[i, :, :],
-                                            flatinfo['edgecoeffs'],
-                                            flatinfo['xranges'],
-                                            var=var[i, :, :],
-                                            ybuffer=ybuffer)
+            result = background.median_1dxd(
+                data[i, :, :],
+                flatinfo['edgecoeffs'],
+                flatinfo['xranges'],
+                var=var[i, :, :],
+                ybuffer=flatinfo['ybuffer'])
+
             data[i, :, :] = result[0]
             var[i, :, :] = result[1]
 
@@ -366,7 +365,7 @@ def combine_images(files:str | list,
     else:
 
         message = '`statistic` is unknown.'
-        raise pySpextool(message)
+        raise pySpextoolError(message)
 
     mean = result[0]
     var = result[1] ** 2
@@ -492,9 +491,11 @@ def combine_images(files:str | list,
 
     if (scale_background or subtract_background or flatfield) is True:
     
-        orders_plotinfo = {'xranges': flatinfo['xranges'],
-                           'edgecoeffs': flatinfo['edgecoeffs'],
-                           'orders': flatinfo['orders']}
+        orders_plotinfo = {
+            'xranges': flatinfo['xranges'],
+            'edgecoeffs': flatinfo['edgecoeffs'],
+            'orders': flatinfo['orders'],
+            'idl_unrotate':flatinfo['rotation']}
 
     else:
 
@@ -502,29 +503,28 @@ def combine_images(files:str | list,
         
     if qa['show'] is True:
         
-        plot_image(mean,
-                   mask=mask,
-                   orders_plotinfo=orders_plotinfo,
-                   figure_size=(setup.plots['square_size'][0]*qa['showscale'],
-                                setup.plots['square_size'][1]*qa['showscale']),
-                   font_size=setup.plots['font_size']*qa['showscale'],
-                   showblock=qa['showblock'],
-                   plot_number=setup.plots['flat'])
-            
+        plot_image(
+            mean,
+            mask=mask,
+            orders_plotinfo=orders_plotinfo,
+            figure_size=(setup.plots['square_size'][0]*qa['showscale'],
+                         setup.plots['square_size'][1]*qa['showscale']),
+            font_size=setup.plots['font_size']*qa['showscale'],
+            showblock=qa['showblock'],
+            plot_number=setup.plots['flat'])
+        
     if qa['write'] is True:
 
         filename = output_fileroot + '_combined' + setup.state['qa_extension']
         fullpath = join(setup.state['qa_path'],filename)
 
-        plot_image(mean,
-                   mask=mask,
-                   orders_plotinfo=orders_plotinfo,
-                   output_fullpath=fullpath,
-                   figure_size=setup.plots['square_size'],
-                   font_size=setup.plots['font_size'])
-
-
-        
+        plot_image(
+            mean,
+            mask=mask,
+            orders_plotinfo=orders_plotinfo,
+            output_fullpath=fullpath,
+            figure_size=setup.plots['square_size'],
+            font_size=setup.plots['font_size'])
 
     #
     # Write the file to disk
@@ -541,11 +541,7 @@ def combine_images(files:str | list,
 
     for i in range(len(keys)):
 
-        if keys[i] == 'COMMENT':
-
-            junk = 1
-
-        else:
+        if keys[i] != 'COMMENT':
 
             hdr[keys[i]] = (avehdr[keys[i]][0], avehdr[keys[i]][1])
 

--- a/src/pyspextool/extract/core.py
+++ b/src/pyspextool/extract/core.py
@@ -12,7 +12,7 @@ def rectify_orders(
     indices:list,
     interpolation_method:str='cubic',
     variance:npt.ArrayLike=None,
-    bad_pixel_mask:npt.ArrayLike=None,
+    badpixel_mask:npt.ArrayLike=None,
     flag_mask:npt.ArrayLike=None,
     ybuffer:int=0,
     nbits:int=8):
@@ -21,7 +21,7 @@ def rectify_orders(
     To rectify spectral orders.
 
     The function "straightens" a spectral order onto a uniform rectangular 
-    grid
+    ndarray of size (nwavelengths, nangles).
 
     Parameters
     ----------
@@ -33,10 +33,73 @@ def rectify_orders(
         with the columns of `img.  That is, orders go left-right and 
         not up-down. 
 
+    indices : list
+        An (norders,) list of dictionaries with the following keys:
+
+        'order' : int
+            The order number.
     
+        'w' : ndarray
+            An (nwavelengths,) array of wavelengths on which the order 
+            is rectified.
+
+        'a' : ndarray
+            An (nangles,) array of angles on which the rectified 
+            order.
+
+        'xidx': ndarray
+            An (nwavelengths, nangles) array of zero-based x positions in `image`
+            at which to interpolate.
+
+        'yidx': ndarray
+            An (nwavelengths, nangles) array of zero-based y positions in `image`
+            at which to interpolate.
+
+    interpolation_method : {'cubic', 'linear'}
+        A string giving the interpolation method passed to 
+        sci.interpolate.RegularGridInterpolator.  
+
+    badpixel_mask : ndarray
+        An (nrows, ncols) bad pixel mask.  Good=1, bad=0.
+
+    flag_mask : ndarray
+        An (nrows, ncols) flag array.  This is a bit-set array with values 
+        up to `nbit`.
+
+    ybuffer : int
+        Number of pixels at the top and bottom of the rectified image set 
+
+    nbits : int, default=8
+        The number of bits used in each pixel of `flag_mask`.
+
     Returns
     -------
+    list
+        An (norders,) list of dictionaries with the following keys:
 
+        'wavelengths' : ndarray
+            An (nwavelengths,) array of wavelengths on which the order 
+            is rectified.
+
+        'angles' : ndarray
+            An (nangles,) array of angles on which the rectified 
+            order.
+
+        'image' : ndarray
+            An (nangles, nwavelengths) array of interpolated values from `image` 
+            at positions indices['xidx'] and indices['yidx'].
+
+        'variance' : ndarray, None
+            An (nangles, nwavelengths) array of interpolated values from `variance` 
+            at positions indices['xidx'] and indices['yidx'].
+
+        'badpixel_mask' : ndarray, None
+            An (nangles, nwavelengths) array of interpolated values from 
+            `badpixel_mask` at positions indices['xidx'] and indices['yidx'].  
+
+        'flag_mask' : ndarray, None
+            An (nangles, nwavelengths) array of interpolated values from 
+            `flagmask_mask` at positions indices['xidx'] and indices['yidx'].  
 
     """
 
@@ -51,16 +114,16 @@ def rectify_orders(
                     indices, 'list', 2)
 
     check_parameter('rectify_orders','interpolation_method', 
-                    interpolation_method, 'str')
+                    interpolation_method, 'str', possible_values=['linear', 'cubic'])
 
     check_parameter('rectify_orders','variance', 
                     variance, ['NoneType', 'ndarray'])
 
-    check_parameter('rectify_orders','bad_pixel_mask', 
-                    bad_pixel_mask, ['NoneType', 'ndarray'])    
+    check_parameter('rectify_orders','badpixel_mask', 
+                    badpixel_mask, ['NoneType', 'ndarray'], 2)    
 
     check_parameter('rectify_orders','flag_mask', 
-                    flag_mask, ['NoneType', 'ndarray'])    
+                    flag_mask, ['NoneType', 'ndarray'], 2)    
     
     check_parameter('rectify_orders','ybuffer', 
                     ybuffer, 'int')
@@ -92,11 +155,11 @@ def rectify_orders(
             variance,
             method=interpolation_method)
 
-    if bad_pixel_mask is not None:
+    if badpixel_mask is not None:
 
         badpixel_function = interpolate.RegularGridInterpolator(
             points, 
-            bad_pixel_mask,
+            badpixel_mask,
             fill_value=1)
 
     if flag_mask is not None:
@@ -150,7 +213,7 @@ def rectify_orders(
         # Do the bad pixel mask if requested.
                 
         rbp = None
-        if bad_pixel_mask is not None:
+        if badpixel_mask is not None:
 
             # The interpolation alone will give values between [0,1] because
             # the original mask has just zeros or ones.  So we floor the values
@@ -178,12 +241,13 @@ def rectify_orders(
 
         # Store the results for return
 
-        rectorders.append({'wavelengths':order['w'],
-                           'angles':order['a'],
-                           'image':rimg,
-                           'variance':rvar,
-                           'badpixel_mask':rbp,
-                           'flag_mask':rfl})
+        rectorders.append(
+            {'wavelengths':order['w'],
+             'angles':order['a'],
+             'image':rimg,
+             'variance':rvar,
+             'badpixel_mask':rbp,
+             'flag_mask':rfl})
 
     return rectorders
 

--- a/src/pyspextool/extract/core.py
+++ b/src/pyspextool/extract/core.py
@@ -1,0 +1,204 @@
+import numpy as np
+import numpy.typing as npt
+from scipy import interpolate
+
+from pyspextool.io.check import check_parameter
+from pyspextool.utils.math import bit_set
+from pyspextool.utils.loop_progress import loop_progress
+
+
+def rectify_orders(    
+    image:npt.ArrayLike,
+    indices:list,
+    interpolation_method:str='cubic',
+    variance:npt.ArrayLike=None,
+    bad_pixel_mask:npt.ArrayLike=None,
+    flag_mask:npt.ArrayLike=None,
+    ybuffer:int=0,
+    nbits:int=8):
+
+    """
+    To rectify spectral orders.
+
+    The function "straightens" a spectral order onto a uniform rectangular 
+    grid
+
+    Parameters
+    ----------
+
+    image : ndarray 
+        An (nrows, ncols) image with (cross-dispersed) spectral orders.  
+        It is assumed that the dispersion direction is roughly aligned 
+        with the rows of `img` and the spatial axis is roughly aligned 
+        with the columns of `img.  That is, orders go left-right and 
+        not up-down. 
+
+    
+    Returns
+    -------
+
+
+    """
+
+    #
+    # Check the parameters
+    #
+
+    check_parameter('rectify_orders','image', 
+                    image, 'ndarray', 2)
+
+    check_parameter('rectify_orders','indices', 
+                    indices, 'list', 2)
+
+    check_parameter('rectify_orders','interpolation_method', 
+                    interpolation_method, 'str')
+
+    check_parameter('rectify_orders','variance', 
+                    variance, ['NoneType', 'ndarray'])
+
+    check_parameter('rectify_orders','bad_pixel_mask', 
+                    bad_pixel_mask, ['NoneType', 'ndarray'])    
+
+    check_parameter('rectify_orders','flag_mask', 
+                    flag_mask, ['NoneType', 'ndarray'])    
+    
+    check_parameter('rectify_orders','ybuffer', 
+                    ybuffer, 'int')
+
+    check_parameter('rectify_orders','nbits', 
+                    nbits, 'int')
+
+    
+    # Get basic info and create basic things
+
+    nrows, ncols = image.shape
+
+    points = (np.arange(nrows), np.arange(ncols))
+
+    #
+    # Get the functions defined first
+    #
+
+
+    image_function = interpolate.RegularGridInterpolator(
+        points, 
+        image,
+        method=interpolation_method)
+
+    if variance is not None:
+
+        variance_function = interpolate.RegularGridInterpolator(
+            points, 
+            variance,
+            method=interpolation_method)
+
+    if bad_pixel_mask is not None:
+
+        badpixel_function = interpolate.RegularGridInterpolator(
+            points, 
+            bad_pixel_mask,
+            fill_value=1)
+
+    if flag_mask is not None:
+
+        
+        flag_function = []
+        for i in range(nbits):
+
+            set = bit_set(flag_mask, i)
+
+            # Do the resampling
+    
+            f = interpolate.RegularGridInterpolator(
+                points, 
+                set, fill_value=0)
+            
+            flag_function.append(f)
+
+    #
+    # Now do the rectifications
+    #
+
+    rectorders = []
+    for order in indices:
+
+        # Do the image first
+
+        rimg = image_function((order['yidx'],order['xidx']))
+    
+        ny, nx = rimg.shape
+
+        # Do the buffering if requested
+
+        if ybuffer > 0:
+
+            rimg[0:ybuffer,:] = np.tile(rimg[ybuffer,:],(ybuffer,1))
+            rimg[ny-ybuffer:,:] = np.tile(rimg[ny-ybuffer-1,:],(ybuffer,1))
+
+        # do the variance if requested.
+
+        rvar=None
+        if variance is not None:
+
+            rvar = variance_function((order['yidx'],order['xidx']))
+
+            if ybuffer > 0:
+                
+                rvar[0:ybuffer,:] = np.tile(rvar[ybuffer,:],(ybuffer,1))
+                rvar[ny-ybuffer:,:] = np.tile(rvar[ny-ybuffer-1,:],(ybuffer,1))
+                
+        # Do the bad pixel mask if requested.
+                
+        rbp = None
+        if bad_pixel_mask is not None:
+
+            # The interpolation alone will give values between [0,1] because
+            # the original mask has just zeros or ones.  So we floor the values
+            # to convert any number that isn't zero to zero.
+        
+            rbp = np.floor(
+                badpixel_function(
+                    (order['yidx'],order['xidx']))).astype('uint8')
+
+        # Do the flag mask if requested.
+
+        rfl = None
+        if flag_mask is not None:
+
+            rfl = np.zeros((ny,nx),dtype=np.uint8)
+            for func in flag_function:
+
+                set = np.floor(
+                    func(
+                        (order['yidx'],order['xidx']))).astype(np.uint8)
+                                   
+                mask = set > 0
+                
+                rfl += np.multiply(mask, (2**i), dtype='uint8')
+
+        # Store the results for return
+
+        rectorders.append({'wavelengths':order['w'],
+                           'angles':order['a'],
+                           'image':rimg,
+                           'variance':rvar,
+                           'badpixel_mask':rbp,
+                           'flag_mask':rfl})
+
+    return rectorders
+
+        
+
+
+
+        
+
+                
+
+            
+
+    
+
+
+
+

--- a/src/pyspextool/extract/extract.py
+++ b/src/pyspextool/extract/extract.py
@@ -1,5 +1,6 @@
 import os
 
+from pyspextool import config as setup
 
 from pyspextool.extract import load_image
 from pyspextool.extract import make_profiles
@@ -9,15 +10,9 @@ from pyspextool.extract import override_aperturesigns
 from pyspextool.extract import trace_apertures
 from pyspextool.extract import define_aperture_parameters
 from pyspextool.extract import extract_apertures
-
-from pyspextool import config as setup
-from pyspextool.extract import config as extract
-
-
+from pyspextool.io.check import check_parameter, check_qakeywords
 from pyspextool.io.files import files_to_fullpath
 from pyspextool.pyspextoolerror import pySpextoolError
-
-
 
 def extract(
     reduction_mode:str,
@@ -28,11 +23,12 @@ def extract(
     aperture_radii:int | float | list,
     output_filenames:str=None,
     output_prefix:str='spectra',
-    input_extension:str='.fits*',
+    input_suffix:str=setup.state['input_suffixes'][0],
     load_directory='raw',
     flat_field=True,
     linearity_correction=True,
     detector_info:dict=None,
+    rectification_method:str='cubic',
     write_rectified_orders:bool=False,
     seeing_fwhm:int | float=0.8,
     profile_ybuffer:int=3,
@@ -49,7 +45,7 @@ def extract(
     psf_radius:int | float=None,
     fix_badpixels:bool=True,
     use_meanprofile:bool=False,
-    badpixel_thresh:int | float=7,                    
+    badpixel_threshold:int | float=7,                    
     verbose:bool=None,
     qa_show:bool=None,
     qa_showscale:float | int=None,
@@ -61,7 +57,10 @@ def extract(
 
     Parameters
     ----------
-    reduction_mode : str
+    reduction_mode : setup.state['reduction_modes']
+        The reduction mode to be used.
+        If 'A', then no pair subtraction is done.
+        If 'A-B', then each pair of images is subtracted.
 
     filenames : str or list
         If type is str, then a comma-separated string of full file names, 
@@ -71,10 +70,11 @@ def extract(
         files[0] is a str giving the perfix, files[1] is a str giving the 
         index numbers of the files, e.g. ['spc', '1-2,5-10,13,14'].
     
+    flat_name : str
+        The full name of a pySpextool flat file.
 
-    flat_name :
-
-    wavecal_name :
+    wavecal_name : str or None
+        The full name of a pySpextool wavecal file.
 
     aperture_findinfo : list
         A (2,) list if
@@ -86,39 +86,118 @@ def extract(
 
         list[0] = 'fixed' then list[1] is a (2,) list giving positions
 
-    aperture_radii :
+    aperture_radii : int, float, list
+        If int or float, then the aperture radius to use for all apertures.
+        If list, then a (naps,) list of aperture radii.  
 
-    output_filenames : str, default=None
-
+    output_filenames : str, list str, optional
+        A str or list of str of output files names.  Only required if 
+        `filenames` gives file names instead of a prefix and index numbers.
+ 
     output_prefix : str, default = 'spectra'
+        The prefix for output spectral files if `filenames` is a (2,) list 
+        with a prefix and index numbers.
 
-    input_extension : str, default = '.fits*'
+    input_suffix : setup.state['reduction_modes'], default='.fits*'
+        The suffix for raw data files.
 
-    load_directory : default = 'raw'
+    load_directory : {'raw', 'proc'}
+        The directory in which to look for raw data.
 
-    flat_field : bool, default = True,
+    flat_field : {True, False}
+        Set to True to flat field the data.
+        Set to False to not flat field the data.
 
-    linearity_correction : bool, default = True,
+    linearity_correction : {True, False}
+        Set to True to correct raw images for non-linearity.
+        Set to False to not correct raw images for non-linearity.
 
-    detector_info : dict, default = None,
+    detector_info : dict, optional
+        A dictionary with any information that needs to be passed to the
+        instrument specific readfits program.  
 
-    write_rectified_orders:bool=False,
+    'rectification_method' : setup.state['rectification_methods']
+        If 'linear', then bi-linear interpolation is used.  See 
+        scipy.interpolate.RegularGridInterpolator.
+
+        If 'cubic', k=3 tensor-product spline is used.  See
+        scipy.interpolate.RegularGridInterpolator.
+
+    write_rectified_orders: {False, True}
+        If False, then the rectified orders are not written to disk.
+        If True, then the rectified orders are written to disk.
 
     seeing_fwhm : float, default = 0.8 (arcseconds).
         The approximate FWHM of the peak to be identified.  Only used 
-        if `method` is 'auto' or 'guess'.
+        if `aperture_findinfo`[0] is 'auto' or 'guess'.
 
-    ybuffer : int, default 3
+    profile_ybuffer : int, default=3
         The number of pixels on the edge of the orders to ignore.  Useful
         as sometimes there is a downturn that can mess with the finding
         routine.
+
+    aperture_signs : list, optional
+        If given, an (naps,) list of aperture signs, e.g. '-','+' that will
+        override results computed by the software.
+
+    include_orders : int, list, str, optional
+        If the type is int, the single order to include.
+        If the type is list, a list of integer orders to include.
+        If the type is str, a str giving the orders, e.g. '1-3,4,5'.
+
+    exclude_orders : int, list, str, optional
+        If the type is int, the single order to exclude.  
+        If the type is list, a list of integer orders to include.
+        If the type is str, a str giving the orders, e.g. '1-3,4,5'.
+
+    trace_fitdegree : int, default=2
+        The polynomial degree for the fit.
+
+    trace_stepsize : int, default=5
+        The step size as the function moves across the array identifying
+        the peaks in the spatial dimension.
+
+    trace_summationwidth : int, default=5
+        The number of columns to combine in order to increase the S/N
+        of the data fit to identify the peaks in the spatial dimension.
+
+    trace_centroidthreshold : int, default=2
+        If (fit-guess) > centroid_threshold to peak identification is found
+        to fail.
+    
+    bg_annulus : list, optional
+        A (2,) list giving the bg start radius and bg width (arcseconds).
+
+    bg_regions : str, optional
+        A string giving bg regions, e.g. '1-2,14,15'.
+
+    bg_fitdegree: int, default=0
+        The polynomial degree of the background fit.
+
+    psf_radius:int, float, optional
+        The PSF radius (in arcsconds) used in optimal extraction.  
+
+    fix_badpixels : {True, False}
+        Set to True to fix bad pixels.  Only used when not optimal extraction.
+        Set to False to not fix bad pixels.  Only used when not optimal 
+        extraction.
+
+    use_meanprofile {False, True}
+        Set to False to use the wavelength-dependent spatial profile for 
+        bad pixel finding and/or optimal extraction.
+
+        Set to True to use the mean of the wavelength-dependent spatial 
+        profile for bad pixel finding and/or optimal extraction.
+
+    badpixel_threshold : int, float, default=7
+        The sigma threshold used to identify bad pixels.
        
     qa_show : {None, True, False}, optional
         Set to True/False to override config.state['qa_show'] in the
         pyspextool config file.  If set to True, quality assurance
         plots will be interactively generated.
 
-    qa_showsize : tuple, default None
+    qa_showsize : tuple, optional
         A (2,) tuple giving the plot size that is passed to matplotlib as,
         pl.figure(figsize=(qa_showsize)) for the interactive plot.
 
@@ -132,6 +211,128 @@ def extract(
         pyspextool config file.
 
     """
+
+    #
+    # Check the parameters and QA keywords
+    #
+
+    check_parameter('extract', 'reduction_mode', 
+                    reduction_mode, 'str', 
+                    possible_values=setup.state['reduction_modes'])
+
+    check_parameter('extract', 'filenames', 
+                    filenames, ['str', 'list'], list_types=['str','str'])
+
+    check_parameter('extract', 'flat_name', 
+                    flat_name, 'str')
+
+    check_parameter('extract', 'wavecal_name', 
+                    wavecal_name, ['NoneType','str'])
+
+    check_parameter('extract', 'aperture_findinfo', 
+                    aperture_findinfo, 'list')
+
+    check_parameter('extract', 'aperture_radii', 
+                    aperture_radii, ['int', 'float','list'])
+
+    check_parameter('extract', 'output_filenames', 
+                    output_filenames, ['NoneType','str','list'])
+
+    check_parameter('extract', 'output_prefix', 
+                    output_prefix, 'str')
+
+    check_parameter('extract', 'input_suffix', 
+                    input_suffix, 'str', 
+                    possible_values=setup.state['input_suffixes'])
+
+    check_parameter('extract', 'load_directory', 
+                    load_directory, 'str', possible_values=['raw','proc'])
+
+    check_parameter('extract', 'flat_field', 
+                    flat_field, 'bool')
+
+    check_parameter('extract', 'linearity_correction', 
+                    linearity_correction, 'bool')
+
+    check_parameter('extract', 'detector_info', 
+                    detector_info, ['dict','NoneType'])
+
+    check_parameter('extract', 'rectification_method', 
+                    rectification_method, 'str', 
+                    possible_values=setup.state['rectification_methods'])
+
+    check_parameter('extract', 'write_rectified_orders', 
+                    write_rectified_orders, 'bool')
+
+    check_parameter('extract', 'seeing_fwhm', 
+                    seeing_fwhm, ['int','float'])
+
+    check_parameter('extract', 'profile_ybuffer', 
+                    profile_ybuffer, 'int')
+
+    check_parameter('extract', 'aperture_signs', 
+                    aperture_signs, ['list', 'NoneType'])
+
+    check_parameter('extract', 'include_orders', 
+                    include_orders, ['NoneType', 'int', 'list', 'str'])
+
+    check_parameter('extract', 'exclude_orders', 
+                    exclude_orders, ['NoneType', 'int', 'list', 'str'])    
+
+    check_parameter("extract", "trace_fitdegree", 
+                    trace_fitdegree, "int")
+    
+    check_parameter("extract", "trace_stepsize", 
+                    trace_stepsize, "int")
+    
+    check_parameter("extract", "trace_summationwidth", 
+                    trace_summationwidth, "int")
+
+    check_parameter("extract", "trace_centroidthreshold", 
+                    trace_centroidthreshold, "int")
+
+    check_parameter('extract', 'bg_annulus', 
+                    bg_annulus, ['ndarray', 'list','NoneType'])    
+
+    check_parameter('extract', 'bg_regions', 
+                    bg_regions, ['str','NoneType'])    
+
+    check_parameter('extract', 'bg_fitdegree', 
+                    bg_fitdegree, ['int','NoneType'])    
+    
+    check_parameter('extract', 'psf_radius', 
+                    psf_radius, ['int','float', 'NoneType'])
+
+    check_parameter('extract', 'fix_badpixels', 
+                    fix_badpixels, 'bool')
+
+    check_parameter('extract', 'use_meanprofile', 
+                    use_meanprofile, 'bool')
+
+    check_parameter('extract', 'badpixel_threshold', 
+                    badpixel_threshold, ['int','float'])
+
+    check_parameter('extract', 'verbose', 
+                    verbose, ['NoneType', 'bool'])
+    
+    check_parameter('extract', 'qa_write', 
+                    qa_write, ['NoneType', 'bool'])
+
+    check_parameter('extract', 'qa_show', 
+                    qa_show, ['NoneType', 'bool'])
+
+    check_parameter('extract', 'qa_showscale', 
+                    qa_showscale, ['int', 'float', 'NoneType'])
+
+    check_parameter('extract', 'qa_showblock', 
+                    qa_showblock, ['NoneType', 'bool'])
+
+    qa = check_qakeywords(
+        verbose=verbose,
+        show=qa_show,
+        showscale=qa_showscale,
+        showblock=qa_showblock,
+        write=qa_write)
 
 
 
@@ -156,7 +357,7 @@ def extract(
         filenames,
         setup.state['nint'],
         setup.state['suffix'],
-        input_extension)
+        input_suffix)
 
     input_fullpaths = results[0]
     file_readmode = results[1]
@@ -256,27 +457,29 @@ def extract(
             wavecal_name,
             output_filenames=output_subset,
             output_prefix=output_prefix,
-            input_extension=input_extension,
+            input_suffix=input_suffix,
             load_directory=load_directory,
             flat_field=flat_field,
             linearity_correction=linearity_correction,
             detector_info=detector_info,
+            rectification_method=rectification_method,
             write_rectified_orders=write_rectified_orders,
             do_all_steps=do_all_steps,
-            verbose=verbose,
-            qa_show=qa_show,
-            qa_showscale=qa_showscale,
-            qa_showblock=qa_showblock,
-            qa_write=qa_write)
+            verbose=qa['verbose'],
+            qa_show=qa['show'],
+            qa_showscale=qa['showscale'],
+            qa_showblock=qa['showblock'],
+            qa_write=qa['write'])
+
 
         # Make the profile
 
         make_profiles(
-            verbose=verbose,
-            qa_show=qa_show,
-            qa_showscale=qa_showscale,
-            qa_showblock=qa_showblock,
-            qa_write=qa_write)
+            verbose=qa['verbose'],
+            qa_show=qa['show'],
+            qa_showscale=qa['showscale'],
+            qa_showblock=qa['showblock'],
+            qa_write=qa['write'])
         
         # Identify apertures
 
@@ -284,11 +487,12 @@ def extract(
             aperture_findinfo,
             seeing_fwhm=seeing_fwhm,
             ybuffer=profile_ybuffer,
-            verbose=verbose,
-            qa_show=qa_show,
-            qa_showscale=qa_showscale,
-            qa_showblock=qa_showblock,
-            qa_write=qa_write)
+            verbose=qa['verbose'],
+            qa_show=qa['show'],
+            qa_showscale=qa['showscale'],
+            qa_showblock=qa['showblock'],
+            qa_write=qa['write'])
+
 
         # Select orders
 
@@ -297,11 +501,11 @@ def extract(
             select_orders(
                 include=include_orders,
                 exclude=exclude_orders,
-                verbose=verbose,
-                qa_show=qa_show,
-                qa_showscale=qa_showscale,
-                qa_showblock=qa_showblock,
-                qa_write=qa_write)
+                verbose=qa['verbose'],
+                qa_show=qa['show'],
+                qa_showscale=qa['showscale'],
+                qa_showblock=qa['showblock'],
+                qa_write=qa['write'])
 
         # Update aperture positions if requested
 
@@ -309,7 +513,7 @@ def extract(
 
             override_aperturesigns(
                 aperture_signs,
-                verbose=verbose)
+                verbose=qa['verbose'])
 
         # Trace the orders
 
@@ -319,11 +523,11 @@ def extract(
             summation_width=trace_summationwidth,
             centroid_threshold=trace_centroidthreshold,
             seeing_fwhm=seeing_fwhm,
-            verbose=verbose,
-            qa_show=qa_show,
-            qa_showscale=qa_showscale,
-            qa_showblock=qa_showblock,
-            qa_write=qa_write)
+            verbose=qa['verbose'],
+            qa_show=qa['show'],
+            qa_showscale=qa['showscale'],
+            qa_showblock=qa['showblock'],
+            qa_write=qa['write'])
         
         # Define the aperture parameters
 
@@ -333,24 +537,23 @@ def extract(
             bg_regions=bg_regions,
             bg_fit_degree=bg_fitdegree,
             psf_radius=psf_radius,
-            verbose=verbose,
-            qa_show=qa_show,
-            qa_showscale=qa_showscale,
-            qa_showblock=qa_showblock,
-            qa_write=qa_write)
+            verbose=qa['verbose'],
+            qa_show=qa['show'],
+            qa_showscale=qa['showscale'],
+            qa_showblock=qa['showblock'],
+            qa_write=qa['write'])
 
         # Extract the apertures
 
         extract_apertures(
             fix_badpixels=fix_badpixels,
             use_meanprofile=use_meanprofile,
-            badpixel_thresh=badpixel_thresh,
-            verbose=verbose,
-            qa_show=qa_show,
-            qa_showscale=qa_showscale,
-            qa_showblock=qa_showblock,
-            qa_write=qa_write)
-
+            badpixel_thresh=badpixel_threshold,
+            verbose=qa['verbose'],
+            qa_show=qa['show'],
+            qa_showscale=qa['showscale'],
+            qa_showblock=qa['showblock'],
+            qa_write=qa['write'])
 
 
 

--- a/src/pyspextool/extract/images.py
+++ b/src/pyspextool/extract/images.py
@@ -1,6 +1,8 @@
 import numpy as np
 import numpy.typing as npt
 from scipy import interpolate
+import time
+from scipy.sparse.linalg import spsolve
 
 from pyspextool.io.check import check_parameter
 from pyspextool.utils.math import bit_set
@@ -116,14 +118,15 @@ def make_ordermask(ncols:int,
 
 
 
-def rectify_order(image:npt.ArrayLike,
-                  xidx:npt.ArrayLike,
-                  yidx:npt.ArrayLike,
-                  variance:npt.ArrayLike=None,
-                  bad_pixel_mask:npt.ArrayLike=None,
-                  flag_mask:npt.ArrayLike=None,
-                  ybuffer:int=0,
-                  nbits:int=8):
+def rectify_order(
+    image:npt.ArrayLike,
+    xidx:npt.ArrayLike,
+    yidx:npt.ArrayLike,
+    variance:npt.ArrayLike=None,
+    bad_pixel_mask:npt.ArrayLike=None,
+    flag_mask:npt.ArrayLike=None,
+    ybuffer:int=0,
+    nbits:int=8):
 
     """
     To rectify a spectral order 
@@ -185,7 +188,13 @@ def rectify_order(image:npt.ArrayLike,
 
     # Do the resampling
     
-    f = interpolate.RegularGridInterpolator(points, image,method='cubic')
+
+
+    f = interpolate.RegularGridInterpolator(
+        points, 
+        image,
+        method='cubic')
+
     image = f((yidx, xidx))
 
     ny, nx = image.shape

--- a/src/pyspextool/extract/load_image.py
+++ b/src/pyspextool/extract/load_image.py
@@ -589,7 +589,7 @@ def load_image(
         img,
         extract.state['rectindices'],
         variance=var,
-        bad_pixel_mask=bad_pixel_mask,
+        badpixel_mask=bad_pixel_mask,
         flag_mask=flag_mask,
         interpolation_method=rectification_method)
 

--- a/src/pyspextool/extract/load_image.py
+++ b/src/pyspextool/extract/load_image.py
@@ -121,45 +121,51 @@ def load_image(
     # Check the parameters and QA keywords
     #
     
-    check_parameter('load_image', 'files', files, ['str', 'list'],
-                    list_types=['str','str'])
+    check_parameter('load_image', 'files', 
+                    files, ['str', 'list'], list_types=['str','str'])
 
-    check_parameter('load_image', 'flat_name', flat_name, 'str')
+    check_parameter('load_image', 'flat_name', 
+                    flat_name, 'str')
 
-    check_parameter('load_image', 'wavecal_name', wavecal_name,
-                    ['NoneType','str'])
+    check_parameter('load_image', 'wavecal_name', 
+                    wavecal_name, ['NoneType','str'])
     
-    check_parameter('load_image', 'output_filenames', output_filenames,
-                    ['NoneType','str','list'])
+    check_parameter('load_image', 'output_filenames', 
+                    output_filenames, ['NoneType','str','list'])
         
-    check_parameter('load_image', 'load_directory', load_directory, 'str',
-                    possible_values=['raw', 'proc'])
+    check_parameter('load_image', 'load_directory', 
+                    load_directory, 'str', possible_values=['raw', 'proc'])
 
-    check_parameter('load_image', 'flat_field', flat_field, 'bool')
+    check_parameter('load_image', 'flat_field', 
+                    flat_field, 'bool')
 
     check_parameter('load_image', 'linearity_correction',
                     linearity_correction, 'bool')
 
-    check_parameter('load_image', 'detector_info', detector_info,
-                    ['NoneType','dict'])
+    check_parameter('load_image', 'detector_info', 
+                    detector_info, ['NoneType','dict'])
     
-    check_parameter('load_image', 'verbose', verbose, ['NoneType', 'bool'])
+    check_parameter('load_image', 'verbose', 
+                    verbose, ['NoneType', 'bool'])
 
-    check_parameter('load_image', 'qa_write', qa_write, ['NoneType', 'bool'])
+    check_parameter('load_image', 'qa_write', 
+                    qa_write, ['NoneType', 'bool'])
 
-    check_parameter('load_image', 'qa_show', qa_show, ['NoneType', 'bool'])
+    check_parameter('load_image', 'qa_show', 
+                    qa_show, ['NoneType', 'bool'])
 
-    check_parameter('load_image', 'qa_showscale', qa_showscale,
-                    ['int', 'float', 'NoneType'])
+    check_parameter('load_image', 'qa_showscale', 
+                    qa_showscale, ['int', 'float', 'NoneType'])
 
-    check_parameter('load_image', 'qa_showblock', qa_showblock,
-                    ['NoneType', 'bool'])
+    check_parameter('load_image', 'qa_showblock', 
+                    qa_showblock, ['NoneType', 'bool'])
     
-    qa = check_qakeywords(verbose=verbose,
-                          show=qa_show,
-                          showscale=qa_showscale,
-                          showblock=qa_showblock,
-                          write=qa_write)
+    qa = check_qakeywords(
+        verbose=verbose,
+        show=qa_show,
+        showscale=qa_showscale,
+        showblock=qa_showblock,
+        write=qa_write)
 
     #
     # Create and ensure that the flat field and wavecal file existence
@@ -414,11 +420,12 @@ def load_image(
                         
         else:
 
-            result = simulate_wavecal_1dxd(flatinfo['ncols'],
-                                           flatinfo['nrows'],
-                                           flatinfo['edgecoeffs'],
-                                           flatinfo['xranges'],
-                                           flatinfo['slith_arc'])
+            result = simulate_wavecal_1dxd(
+                flatinfo['ncols'],
+                flatinfo['nrows'],
+                flatinfo['edgecoeffs'],
+                flatinfo['xranges'],
+                flatinfo['slith_arc'])
 
             wavecal = result[0]
             spatcal = result[1]            
@@ -604,30 +611,33 @@ def load_image(
 
     orders_plotinfo = {'xranges': extract.state['xranges'],
                        'edgecoeffs': extract.state['edgecoeffs'],
-                       'orders': extract.state['orders']}
+                       'orders': extract.state['orders'],
+                       'idl_unrotate':0}
               
     if qa['show'] is True:
         
-        plot_image(img,
-                   mask=linearity_mask,
-                   orders_plotinfo=orders_plotinfo,
-                   figure_size=(setup.plots['square_size'][0]*qa['showscale'],
-                                setup.plots['square_size'][1]*qa['showscale']),
-                   font_size=setup.plots['font_size']*qa['showscale'],
-                   showblock=qa['showblock'],
-                   plot_number=setup.plots['combine_image'])
-            
+        plot_image(
+            img,
+            mask=linearity_mask,
+            orders_plotinfo=orders_plotinfo,
+            figure_size=(setup.plots['square_size'][0]*qa['showscale'],
+                         setup.plots['square_size'][1]*qa['showscale']),
+            font_size=setup.plots['font_size']*qa['showscale'],
+            showblock=qa['showblock'],
+            plot_number=setup.plots['combine_image'])
+        
     if qa['write'] is True:
 
         filename = qafilename + '_image' + setup.state['qa_extension']
         fullpath = join(setup.state['qa_path'],filename)
 
-        plot_image(img,
-                   mask=linearity_mask,
-                   orders_plotinfo=orders_plotinfo,
-                   output_fullpath=fullpath,
-                   figure_size=setup.plots['square_size'],
-                   font_size=setup.plots['font_size'])
+        plot_image(
+            img,
+            mask=linearity_mask,
+            orders_plotinfo=orders_plotinfo,
+            output_fullpath=fullpath,
+            figure_size=setup.plots['square_size'],
+            font_size=setup.plots['font_size'])
 
     #
     # Write rectified orders

--- a/src/pyspextool/extract/load_image.py
+++ b/src/pyspextool/extract/load_image.py
@@ -4,6 +4,7 @@ from astropy.io import fits
 from os.path import join, basename as osbasename, splitext
 import logging
 import glob
+#import time
 
 from pyspextool import config as setup
 from pyspextool.extract import config as extract
@@ -22,6 +23,9 @@ from pyspextool.utils.loop_progress import loop_progress
 from pyspextool.utils.math import combine_flag_stack
 from pyspextool.pyspextoolerror import pySpextoolError
 
+from pyspextool.extract.core import rectify_orders
+
+
 
 def load_image(
     files:str | list,
@@ -29,11 +33,12 @@ def load_image(
     wavecal_name:str,
     output_filenames:str=None,
     output_prefix:str='spectra',
-    input_extension:str='.fits*',
+    input_suffix:str='.fits*',
     load_directory='raw',
     flat_field=True,
     linearity_correction=True,
     detector_info:dict=None,
+    rectification_method='cubic',
     write_rectified_orders:bool=False,
     do_all_steps:bool=False,
     verbose:bool=None,
@@ -210,7 +215,7 @@ def load_image(
         files,
         setup.state['nint'],
         setup.state['suffix'],
-        input_extension)
+        input_suffix)
 
     input_files = results[0]
     file_readmode = results[1]
@@ -576,34 +581,46 @@ def load_image(
     # Rectify the orders
     #
 
-    logging.info(' Rectifying the orders.')                
-    
-    rectorders = []
-    indices = extract.state['rectindices']
-    for i in range(extract.state['norders']):
+    logging.info(' Rectifying the orders.  Method='+rectification_method)
+            
+#    start = time.perf_counter()
+ 
+    extract.state['rectorders'] = rectify_orders(            
+        img,
+        extract.state['rectindices'],
+        variance=var,
+        bad_pixel_mask=bad_pixel_mask,
+        flag_mask=flag_mask,
+        interpolation_method=rectification_method)
 
-        loop_progress(i,0,extract.state['norders'])
-        result = rectify_order(
-            img,
-            indices[i]['xidx'],
-            indices[i]['yidx'],
-            variance=var,
-            bad_pixel_mask=bad_pixel_mask,
-            flag_mask=flag_mask)
+#    rectorders = []
+#    for i in range(extract.state['norders']):
+#
+#        result = rectify_order(
+#            img,
+#            indices[i]['xidx'],
+#            indices[i]['yidx'],
+#            variance=var,
+#            bad_pixel_mask=bad_pixel_mask,
+#            flag_mask=flag_mask)
+#
+#
+#        rectorder = {'wavelengths':indices[i]['w'],
+#                     'angles':indices[i]['a'],
+#                     'image':result['image'],
+#                     'variance':result['variance'],
+#                     'badpixel_mask':result['bpmask'],
+#                     'flag_mask':result['flagmask']}
+#
+#        rectorders.append(rectorder)        
+#
+#   # Store the results
+#
+#    extract.state['rectorders'] = rectorders
+#
+#    end = time.perf_counter()
+#    print(f"Elapsed time: {end - start:.6f} seconds")
 
-        rectorder = {'wavelengths':indices[i]['w'],
-                     'angles':indices[i]['a'],
-                     'image':result['image'],
-                     'variance':result['variance'],
-                     'badpixel_mask':result['bpmask'],
-                     'flag_mask':result['flagmask']}
-
-        rectorders.append(rectorder)        
-
-
-    # Store the results
-
-    extract.state['rectorders'] = rectorders
 
     #        
     # Make the QA plot
@@ -644,6 +661,8 @@ def load_image(
     #
 
     if write_rectified_orders is True:
+
+        rectorders = extract.state['rectorders']
 
         # Get output file name 
         

--- a/src/pyspextool/extract/make_flat.py
+++ b/src/pyspextool/extract/make_flat.py
@@ -155,7 +155,7 @@ def make_flat(
         files,
         setup.state['nint'],
         setup.state['suffix'],
-        setup.state['search_extension'])
+        setup.state['input_suffix'])
         
     files = result[0]
     

--- a/src/pyspextool/extract/make_flat.py
+++ b/src/pyspextool/extract/make_flat.py
@@ -2,10 +2,9 @@ import importlib
 from os.path import join, basename
 import numpy as np
 import logging
-from decimal import *
+from decimal import Decimal, getcontext
 
 from pyspextool import config as setup
-from pyspextool.extract import config as extract
 from pyspextool.io.check import check_parameter, check_qakeywords
 from pyspextool.io.files import files_to_fullpath
 from pyspextool.io.fitsheader import average_headerinfo
@@ -15,19 +14,19 @@ from pyspextool.extract.images import make_ordermask
 from pyspextool.plot.plot_image import plot_image
 from pyspextool.utils import math
 from pyspextool.utils.split_text import split_text
-from pyspextool.utils.arrays import idl_rotate
 
 
-def make_flat(files:list | str,
-              output_name:str,
-              linearity_correction=False,
-              detector_info:dict=None,
-              normalize:bool=True,
-              verbose:bool=None,
-              qa_show:bool=None,
-              qa_showscale:int | float=None,
-              qa_showblock:bool=None,
-              qa_write:bool=None):
+def make_flat(
+    files:list | str,
+    output_name:str,
+    linearity_correction=False,
+    detector_info:dict=None,
+    normalize:bool=True,
+    verbose:bool=None,
+    qa_show:bool=None,
+    qa_showscale:int | float=None,
+    qa_showblock:bool=None,
+    qa_write:bool=None):
 
     """
     To create a (normalized) pySpextool flat field file.
@@ -93,35 +92,42 @@ def make_flat(files:list | str,
     # Check the input parmameters
     #
 
-    check_parameter('make_flat', 'files', files, ['str', 'list'])
+    check_parameter('make_flat', 'files', 
+                    files, ['str', 'list'])
 
-    check_parameter('make_flat', 'output_name', output_name, 'str')
+    check_parameter('make_flat', 'output_name', 
+                    output_name, 'str')
 
-    check_parameter('make_flat', 'linearity_correction', linearity_correction,
-                    'bool')
+    check_parameter('make_flat', 'linearity_correction', 
+                    linearity_correction, 'bool')
 
-    check_parameter('make_flat', 'detector_info', detector_info,
-                    ['dict', 'NoneType'])
+    check_parameter('make_flat', 'detector_info', 
+                    detector_info, ['dict', 'NoneType'])
     
-    check_parameter('make_flat', 'normalize', normalize, 'bool')
+    check_parameter('make_flat', 'normalize', 
+                    normalize, 'bool')
 
-    check_parameter('make_flat', 'verbose', verbose, ['NoneType', 'bool'])
+    check_parameter('make_flat', 'verbose', 
+                    verbose, ['NoneType', 'bool'])
 
-    check_parameter('make_flat', 'qa_write', qa_write, ['NoneType', 'bool'])
+    check_parameter('make_flat', 'qa_write', 
+                    qa_write, ['NoneType', 'bool'])
 
-    check_parameter('make_flat', 'qa_show', qa_show, ['NoneType', 'bool'])
+    check_parameter('make_flat', 'qa_show', 
+                    qa_show, ['NoneType', 'bool'])
 
-    check_parameter('make_flat', 'qa_showscale', qa_showscale,
-                    ['NoneType', 'int', 'float'])    
+    check_parameter('make_flat', 'qa_showscale', 
+                    qa_showscale, ['NoneType', 'int', 'float'])    
 
-    check_parameter('make_flat', 'qa_showblock', qa_showblock,
-                    ['NoneType', 'bool'])
+    check_parameter('make_flat', 'qa_showblock', 
+                    qa_showblock, ['NoneType', 'bool'])
     
-    qa = check_qakeywords(verbose=verbose,
-                          show=qa_show,
-                          showscale=qa_showscale,
-                          showblock=qa_showblock,
-                          write=qa_write)        
+    qa = check_qakeywords(
+        verbose=verbose,
+        show=qa_show,
+        showscale=qa_showscale,
+        showblock=qa_showblock,
+        write=qa_write)        
     #
     # Let the user know what you are doing.
     #
@@ -144,21 +150,22 @@ def make_flat(files:list | str,
 
     # Create the file names
 
-    result = files_to_fullpath(setup.state['raw_path'],
-                               files,
-                               setup.state['nint'],
-                               setup.state['suffix'],
-                               setup.state['search_extension'])
+    result = files_to_fullpath(
+        setup.state['raw_path'],
+        files,
+        setup.state['nint'],
+        setup.state['suffix'],
+        setup.state['search_extension'])
         
     files = result[0]
-    readmode = result[1]
     
     # Get the mode name from the first file in order to get the array
     # rotation value.
 
-    result = instr.read_fits(files,
-                             setup.state['linearity_info'],
-                             verbose=False)
+    result = instr.read_fits(
+        files,
+        setup.state['linearity_info'],
+        verbose=False)
     hdr = result[2]
     
     mode = hdr[0]['MODE'][0]
@@ -169,16 +176,17 @@ def make_flat(files:list | str,
     # Load the FITS files into memory
 
     logging.info(' Loading the images.')
-    result = instr.read_fits(files,
-                             setup.state['linearity_info'],
-                             rotate=modeinfo['rotation'],
-                             keywords=setup.state['extract_keywords'],
-                             linearity_correction=linearity_correction,
-                             extra=detector_info,
-                             verbose=qa['verbose'])
+    result = instr.read_fits(
+        files,
+        setup.state['linearity_info'],
+        rotate=modeinfo['rotation'],
+        keywords=setup.state['extract_keywords'],
+        linearity_correction=linearity_correction,
+        extra=detector_info,
+        verbose=qa['verbose'])
     
     img = result[0]
-    var = result[1]
+#    var = result[1]
     hdr = result[2]
     mask = result[3]
 
@@ -225,24 +233,25 @@ def make_flat(files:list | str,
             
     logging.info(' Locating the orders.')
 
-    result = locate_orders(med,
-                           modeinfo['guesspos'],
-                           modeinfo['xranges'],
-                           modeinfo['step'],
-                           modeinfo['slith_range'],
-                           modeinfo['edgedeg'],
-                           modeinfo['ybuffer'],
-                           modeinfo['flatfrac'],
-                           modeinfo['comwidth'],
-                           qa_plotnumber=setup.plots['locate_orders'],
-                           qa_fontsize=setup.plots['font_size'],
-                           qa_figuresize=setup.plots['square_size'],
-                           qa_show=qa['show'],
-                           qa_showblock=qa['showblock'],
-                           qa_showscale=qa['showscale'],
-                           qa_fullpath=fullpath,
-                           debug=False)
-
+    result = locate_orders(
+        med,
+        modeinfo['guesspos'],
+        modeinfo['xranges'],
+        modeinfo['step'],
+        modeinfo['slith_range'],
+        modeinfo['edgedeg'],
+        modeinfo['ybuffer'],
+        modeinfo['flatfrac'],
+        modeinfo['comwidth'],
+        qa_plotnumber=setup.plots['locate_orders'],
+        qa_fontsize=setup.plots['font_size'],
+        qa_figuresize=setup.plots['square_size'],
+        qa_show=qa['show'],
+        qa_showblock=qa['showblock'],
+        qa_showscale=qa['showscale'],
+        qa_fullpath=fullpath,
+        debug=False)
+    
     edgecoeffs = result[0]
     xranges = result[1]
 
@@ -254,16 +263,17 @@ def make_flat(files:list | str,
 
         logging.info(' Normalizing the median flat.')
 
-        nimg, nvar, rms = normalize_flat(med,
-                                         edgecoeffs,
-                                         xranges,
-                                         modeinfo['slith_arc'],
-                                         modeinfo['nxgrid'],
-                                         modeinfo['nygrid'],
-                                         var=munc ** 2,
-                                         ybuffer=modeinfo['ybuffer'],
-                                         verbose=qa['verbose'])
-
+        nimg, nvar, rms = normalize_flat(
+            med,
+            edgecoeffs,
+            xranges,
+            modeinfo['slith_arc'],
+            modeinfo['nxgrid'],
+            modeinfo['nygrid'],
+            var=munc ** 2,
+            ybuffer=modeinfo['ybuffer'],
+            verbose=qa['verbose'])
+        
     else:
 
         nimg = med
@@ -280,11 +290,12 @@ def make_flat(files:list | str,
     #
 
     nrows, ncols = np.shape(med)
-    ordermask = make_ordermask(ncols,
-                               nrows,
-                               edgecoeffs,
-                               xranges,
-                               modeinfo['orders'])
+    ordermask = make_ordermask(
+        ncols,
+        nrows,
+        edgecoeffs,
+        xranges,
+        modeinfo['orders'])
 
     #        
     # Make the QA plot
@@ -292,31 +303,34 @@ def make_flat(files:list | str,
     
     orders_plotinfo = {'edgecoeffs': edgecoeffs,
                        'xranges': xranges,
-                       'orders': modeinfo['orders']}
+                       'orders': modeinfo['orders'],
+                       'idl_unrotate':0}
               
     if qa['show'] is True:
         
-        plot_image(nimg,
-                   mask=flag,
-                   orders_plotinfo=orders_plotinfo,
-                   figure_size=(setup.plots['square_size'][0]*qa['showscale'],
-                                setup.plots['square_size'][1]*qa['showscale']),
-                   font_size=setup.plots['font_size']*qa['showscale'],
-                   showblock=qa['showblock'],
-                   plot_number=setup.plots['flat'])
-            
+        plot_image(
+            nimg,
+            mask=flag,
+            orders_plotinfo=orders_plotinfo,
+            figure_size=(setup.plots['square_size'][0]*qa['showscale'],
+                         setup.plots['square_size'][1]*qa['showscale']),
+            font_size=setup.plots['font_size']*qa['showscale'],
+            showblock=qa['showblock'],
+            plot_number=setup.plots['flat'])
+        
     if qa['write'] is True:
 
         filename = output_name + '_normalized' + setup.state['qa_extension']
         fullpath = join(setup.state['qa_path'],filename)
 
-        plot_image(nimg,
-                   mask=flag,
-                   orders_plotinfo=orders_plotinfo,
-                   output_fullpath=fullpath,
-                   figure_size=setup.plots['square_size'],
-                   font_size=setup.plots['font_size'])
-
+        plot_image(
+            nimg,
+            mask=flag,
+            orders_plotinfo=orders_plotinfo,
+            output_fullpath=fullpath,
+            figure_size=setup.plots['square_size'],
+            font_size=setup.plots['font_size'])
+        
     #
     # Write the file to disk
     #
@@ -349,27 +363,28 @@ def make_flat(files:list | str,
     
     output_fullpath =  join(setup.state['cal_path'], output_name + '.fits')
 
-    write_flat(nimg,
-               nvar,
-               flag,
-               ordermask,
-               average_header,
-               modeinfo['rotation'],
-               modeinfo['orders'],
-               edgecoeffs,
-               xranges,
-               modeinfo['ybuffer'],
-               modeinfo['ps'],
-               modeinfo['slith_pix'],
-               modeinfo['slith_arc'],
-               slitw_pix,
-               slitw_arc,
-               mode,
-               rms,
-               resolvingpower,
-               setup.state['version'],
-               history,
-               output_fullpath,
-               overwrite=True)
-
+    write_flat(
+        nimg,
+        nvar,
+        flag,
+        ordermask,
+        average_header,
+        modeinfo['rotation'],
+        modeinfo['orders'],
+        edgecoeffs,
+        xranges,
+        modeinfo['ybuffer'],
+        modeinfo['ps'],
+        modeinfo['slith_pix'],
+        modeinfo['slith_arc'],
+        slitw_pix,
+        slitw_arc,
+        mode,
+        rms,
+        resolvingpower,
+        setup.state['version'],
+        history,
+        output_fullpath,
+        overwrite=True)
+    
     logging.info(' Flat field file ' + output_name + '.fits written to disk.\n')

--- a/src/pyspextool/extract/make_wavecal.py
+++ b/src/pyspextool/extract/make_wavecal.py
@@ -187,7 +187,7 @@ def make_wavecal(
         arc_files,
         setup.state['nint'],
         setup.state['suffix'],
-        setup.state['search_extension'])
+        setup.state['input_suffix'])
 
     arcs_fullpath = result[0]
 

--- a/src/pyspextool/extract/make_wavecal.py
+++ b/src/pyspextool/extract/make_wavecal.py
@@ -16,21 +16,22 @@ from pyspextool.utils.math import median_data_stack
 from pyspextool.utils.math import combine_flag_stack
 from pyspextool.pyspextoolerror import pySpextoolError
 
-def make_wavecal(arc_files:str | list,
-                 flat_file:str,
-                 output_filename:str,
-                 sky_files:str=None,
-                 linearity_correction=True,
-                 detector_info:dict=None,
-                 use_stored_solution:bool=False,
-                 verbose:bool=None,
-                 saturation_fraction:float=0.3,
-                 ignore_saturation_error:bool=False,
-                 qa_show:bool=None,
-                 qa_showscale:float | int=None,
-                 qa_showblock:bool=None,
-                 qa_write_findlines:bool=False,
-                 qa_write:bool=None):
+def make_wavecal(
+    arc_files:str | list,
+    flat_file:str,
+    output_filename:str,
+    sky_files:str=None,
+    linearity_correction=True,
+    detector_info:dict=None,
+    use_stored_solution:bool=False,
+    verbose:bool=None,
+    saturation_fraction:float=0.3,
+    ignore_saturation_error:bool=False,
+    qa_show:bool=None,
+    qa_showscale:float | int=None,
+    qa_showblock:bool=None,
+    qa_write_findlines:bool=False,
+    qa_write:bool=None):
 
 
     """
@@ -119,42 +120,49 @@ def make_wavecal(arc_files:str | list,
     # Check parameters and keywords
     #
 
-    check_parameter('make_wavecal', 'arc_files', arc_files, ['str', 'list'],
+    check_parameter('make_wavecal', 'arc_files', 
+                    arc_files, ['str', 'list'], list_types=['str','str'])
+
+    check_parameter('make_wavecal', 'flat_file', 
+                    flat_file, 'str')
+
+    check_parameter('make_wavecal', 'output_filename', 
+                    output_filename, 'str')
+
+    check_parameter('make_wavecal', 'sky_files', 
+                    sky_files, ['str', 'list','NoneType'], 
                     list_types=['str','str'])
-
-    check_parameter('make_wavecal', 'flat_file', flat_file, 'str')
-
-    check_parameter('make_wavecal', 'output_filename', output_filename, 'str')
-
-    check_parameter('make_wavecal', 'sky_files', sky_files,
-                    ['str', 'list','NoneType'], list_types=['str','str'])
 
     check_parameter('make_wavecal', 'linearity_correction',
                     linearity_correction, 'bool')
 
-    check_parameter('make_wavecal', 'detector_info', detector_info,
-                    ['dict', 'NoneType'])
+    check_parameter('make_wavecal', 'detector_info', 
+                    detector_info, ['dict', 'NoneType'])
 
     check_parameter('make_wavecal', 'use_stored_solution',
                     use_stored_solution, 'bool')
 
-    check_parameter('get_wavecal', 'verbose', verbose, ['NoneType','bool'])
+    check_parameter('get_wavecal', 'verbose', 
+                    verbose, ['NoneType','bool'])
 
-    check_parameter('get_wavecal', 'qa_show', qa_show, ['NoneType','bool'])
+    check_parameter('get_wavecal', 'qa_show', 
+                    qa_show, ['NoneType','bool'])
 
-    check_parameter('get_wavecal', 'qa_showscale', qa_showscale,
-                    ['NoneType','float','int'])
+    check_parameter('get_wavecal', 'qa_showscale', 
+                    qa_showscale, ['NoneType','float','int'])
     
-    check_parameter('get_wavecal', 'qa_showblock', qa_showblock,
-                    ['NoneType','bool'])
+    check_parameter('get_wavecal', 'qa_showblock', 
+                    qa_showblock, ['NoneType','bool'])
         
-    check_parameter('get_wavecal', 'qa_write', qa_write, ['NoneType','bool'])
+    check_parameter('get_wavecal', 'qa_write', 
+                    qa_write, ['NoneType','bool'])
 
-    qa = check_qakeywords(verbose=verbose,
-                          show=qa_show,
-                          showscale=qa_showscale,
-                          showblock=qa_showblock,
-                          write=qa_write)
+    qa = check_qakeywords(
+        verbose=verbose,
+        show=qa_show,
+        showscale=qa_showscale,
+        showblock=qa_showblock,
+        write=qa_write)
 
     #
     # Let the user know what you are doing.
@@ -174,21 +182,23 @@ def make_wavecal(arc_files:str | list,
 
     flat_fullpath = os.path.join(setup.state['cal_path'], flat_file)
     
-    result = files_to_fullpath(setup.state['raw_path'],
-                               arc_files,
-                               setup.state['nint'],
-                               setup.state['suffix'],
-                               setup.state['search_extension'])
+    result = files_to_fullpath(
+        setup.state['raw_path'],
+        arc_files,
+        setup.state['nint'],
+        setup.state['suffix'],
+        setup.state['search_extension'])
 
     arcs_fullpath = result[0]
 
     if sky_files is not None:
 
-        result = files_to_fullpath(setup.state['raw_path'],
-                                   sky_files,
-                                   setup.state['nint'],
-                                   setup.state['suffix'],
-                                   setup.state['search_extension'])
+        result = files_to_fullpath(
+            setup.state['raw_path'],
+            sky_files,
+            setup.state['nint'],
+            setup.state['suffix'],
+            setup.state['search_extension'])
 
         skys_fullpath = result[0]
 
@@ -203,19 +213,20 @@ def make_wavecal(arc_files:str | list,
     # Create the image
     #
 
-    result = _make_wavecal_image(arcs_fullpath,
-                                 skys_fullpath,
-                                 linearity_correction,
-                                 detector_info,
-                                 flat_fullpath,
-                                 qa['verbose'],
-                                 setup.plots['wavecal_image'],
-                                 setup.plots['square_size'],
-                                 setup.plots['font_size'],
-                                 qa['show'],
-                                 qa['showscale'],
-                                 qa['showblock'],    
-                                 qa['write'])
+    result = _make_wavecal_image(
+        arcs_fullpath,
+        skys_fullpath,
+        linearity_correction,
+        detector_info,
+        flat_fullpath,
+        qa['verbose'],
+        setup.plots['wavecal_image'],
+        setup.plots['square_size'],
+        setup.plots['font_size'],
+        qa['show'],
+        qa['showscale'],
+        qa['showblock'],    
+        qa['write'])
 
     flatinfo = result[0]
     wavecalinfo = result[1]
@@ -273,11 +284,12 @@ def make_wavecal(arc_files:str | list,
 
     # Create wavecal and spatcal images
 
-    result = wavecal.simulate_wavecal_1dxd(flatinfo['ncols'],
-                                           flatinfo['nrows'],
-                                           flatinfo['edgecoeffs'],
-                                           flatinfo['xranges'],
-                                           flatinfo['slith_arc'])
+    result = wavecal.simulate_wavecal_1dxd(
+        flatinfo['ncols'],
+        flatinfo['nrows'],
+        flatinfo['edgecoeffs'],
+        flatinfo['xranges'],
+        flatinfo['slith_arc'])
 
     wavecal_pixels = result[0]
     spatcal = result[1]
@@ -294,16 +306,17 @@ def make_wavecal(arc_files:str | list,
         ' orders (without background subtraction).'
     logging.info(message)
 
-    spectra = extract_1dxd(wavecal_image,
-                           wavecal_mask,
-                           flatinfo['ordermask'],
-                           wavecal_pixels,
-                           spatcal,
-                           flatinfo['orders'],
-                           tracecoeffs,
-                           aperture_radii,
-                           np.full((1),1),
-                           progressbar=qa['verbose'])
+    spectra = extract_1dxd(
+        wavecal_image,
+        wavecal_mask,
+        flatinfo['ordermask'],
+        wavecal_pixels,
+        spatcal,
+        flatinfo['orders'],
+        tracecoeffs,
+        aperture_radii,
+        np.full((1),1),
+        progressbar=qa['verbose'])
 
     #
     # Find the pixel offset between these spectra and the disk spectra
@@ -332,19 +345,20 @@ def make_wavecal(arc_files:str | list,
 
         fullpath = None
 
-    offset = wavecal.get_spectral_pixelshift(xanchor,
-                                     fanchor,
-                                     xsource,
-                                     fsource,
-                                     qa_plotnumber=setup.plots['pixel_shift'],
-                                     qa_figuresize=setup.plots['portrait_size'],
-                                     qa_fontsize=setup.plots['font_size'],
-                                     qa_show=qa['show'],
-                                     qa_showscale=qa['showscale'],
-                                     qa_showblock=qa['showblock'],
-                                     qa_fullpath=fullpath,
-                                     anchor_label='Stored Spectrum', 
-                                     source_label='Observed Spectrum')
+    offset = wavecal.get_spectral_pixelshift(
+        xanchor,
+        fanchor,
+        xsource,
+        fsource,
+        qa_plotnumber=setup.plots['pixel_shift'],
+        qa_figuresize=setup.plots['portrait_size'],
+        qa_fontsize=setup.plots['font_size'],
+        qa_show=qa['show'],
+        qa_showscale=qa['showscale'],
+        qa_showblock=qa['showblock'],
+        qa_fullpath=fullpath,
+        anchor_label='Stored Spectrum', 
+        source_label='Observed Spectrum')
 
     #
     # Are we using the stored solution?
@@ -373,15 +387,17 @@ def make_wavecal(arc_files:str | list,
         filename = os.path.join(setup.state['instrument_path'], 
                                 wavecalinfo['linelist'])
 
-        lineinfo = wavecal.read_line_list(filename,
-                                          delta_to_microns=True)
+        lineinfo = wavecal.read_line_list(
+            filename,
+            delta_to_microns=True)
         
         #  Determine the guess position and search range for each
     
-        lineinfo = wavecal.get_line_guess_position(wavecalinfo['spectra'],
-                                                   wavecalinfo['orders'],
-                                                   wavecalinfo['xranges'],
-                                                   lineinfo)
+        lineinfo = wavecal.get_line_guess_position(
+            wavecalinfo['spectra'],
+            wavecalinfo['orders'],
+            wavecalinfo['xranges'],
+            lineinfo)
         
         # Add the shift offset to the results
 
@@ -405,15 +421,16 @@ def make_wavecal(arc_files:str | list,
 
         # Find the lines
     
-        lineinfo = wavecal.find_lines_1dxd(spectra,
-                                   wavecalinfo['orders'],
-                                   lineinfo,
-                                   flatinfo['slitw_pix'],
-                                   qa_figuresize=setup.plots['portrait_size'],
-                                   qa_fontsize=setup.plots['font_size'],
-                                   qa_fullpath=fullpath,
-                                   verbose=qa['verbose'])
-
+        lineinfo = wavecal.find_lines_1dxd(
+            spectra,
+            wavecalinfo['orders'],
+            lineinfo,
+            flatinfo['slitw_pix'],
+            qa_figuresize=setup.plots['portrait_size'],
+            qa_fontsize=setup.plots['font_size'],
+            qa_fullpath=fullpath,
+            verbose=qa['verbose'])
+        
         #
         # Let's do the actual calibration
         #
@@ -446,17 +463,19 @@ def make_wavecal(arc_files:str | list,
 
         # Find the solution
 
-        solution = wavecal.wavecal_solution_1d(wavecalinfo['orders'],
-                                       lineinfo,
-                                       wavecalinfo['dispdeg'],
-                                       xd_info=xdinfo,
-                                       verbose=qa['verbose'],
-                            qa_plotnumber=setup.plots['wavecal_residuals'],
-                                       qa_figuresize=figure_size,
-                                       qa_fontsize=setup.plots['font_size'],
-                                       qa_show=qa['show'],
-                                       qa_showblock=qa['showblock'],
-                                       qa_fullpath=fullpath)
+        solution = wavecal.wavecal_solution_1d(
+            wavecalinfo['orders'],
+            lineinfo,
+            wavecalinfo['dispdeg'],
+            xd_info=xdinfo,
+            verbose=qa['verbose'],
+            qa_plotnumber=setup.plots['wavecal_residuals'],
+            qa_figuresize=figure_size,
+            qa_fontsize=setup.plots['font_size'],
+            qa_show=qa['show'],
+            qa_showblock=qa['showblock'],
+            qa_fullpath=fullpath)
+
         stored_solution_offset = 0.0
 
     else:
@@ -482,10 +501,11 @@ def make_wavecal(arc_files:str | list,
 
     indices = []
     for i in range(flatinfo['norders']):
-        idxs = wavecal.make_interp_indices_1d(flatinfo['edgecoeffs'][i, :, :],
-                                              flatinfo['xranges'][i, :],
-                                              flatinfo['slith_arc'],
-                                              array_output=True)
+        idxs = wavecal.make_interp_indices_1d(
+            flatinfo['edgecoeffs'][i, :, :],
+            flatinfo['xranges'][i, :],
+            flatinfo['slith_arc'],
+            array_output=True)
               
         indices.append(idxs)
         
@@ -506,44 +526,46 @@ def make_wavecal(arc_files:str | list,
 
     oname = os.path.join(setup.state['cal_path'], output_filename + '.fits')
         
-    wavecal.write_wavecal1d_fits(flatinfo['ordermask'],                         
-                                 flatinfo['xranges'],
-                                 solution['coeffs'],
-                                 solution['covar'],
-                                 wavecalinfo['dispdeg'],
-                                 solution['rms'] * 1e4,
-                                 solution['nlines'],
-                                 solution['ngood'],
-                                 solution['nbad'],
-                                 wavecal_pixels,
-                                 stored_solution_offset,
-                                 spatcal,
-                                 indices,
-                                 flatinfo['rotation'],
-                                 flat_file,
-                                 skys_filenames,
-                                 oname,
-                                 setup.state['version'],
-                                 xdinfo=xdinfo,
-                                 stored_solution=use_stored_solution)
+    wavecal.write_wavecal1d_fits(
+        flatinfo['ordermask'],                         
+        flatinfo['xranges'],
+        solution['coeffs'],
+        solution['covar'],
+        wavecalinfo['dispdeg'],
+        solution['rms'] * 1e4,
+        solution['nlines'],
+        solution['ngood'],
+        solution['nbad'],
+        wavecal_pixels,
+        stored_solution_offset,
+        spatcal,
+        indices,
+        flatinfo['rotation'],
+        flat_file,
+        skys_filenames,
+        oname,
+        setup.state['version'],
+        xdinfo=xdinfo,
+        stored_solution=use_stored_solution)
 
     logging.info(' Wavecal file ' + output_filename + \
                  '.fits written to disk.\n')
 
 
-def _make_wavecal_image(arc_files:str | list,
-                        sky_files:str | list | None,
-                        linearity_correction:bool,
-                        detector_info:dict | None,
-                        flat_file:str,
-                        verbose:bool,
-                        qa_plotnumber:int,
-                        qa_figuresize:tuple,
-                        qa_fontsize:int,
-                        qa_show:bool,
-                        qa_showscale:bool,
-                        qa_showblock:bool,
-                        qa_write:bool):
+def _make_wavecal_image(
+    arc_files:str | list,
+    sky_files:str | list | None,
+    linearity_correction:bool,
+    detector_info:dict | None,
+    flat_file:str,
+    verbose:bool,
+    qa_plotnumber:int,
+    qa_figuresize:tuple,
+    qa_fontsize:int,
+    qa_show:bool,
+    qa_showscale:bool,
+    qa_showblock:bool,
+    qa_write:bool):
     
     """
     Creates an "arc" image using arc and sky images for wavelength calibration.
@@ -616,43 +638,44 @@ def _make_wavecal_image(arc_files:str | list,
     # Check parameters and keywords
     #
 
-    check_parameter('_make_wavecal_image', 'arc_files', arc_files, 
-                    ['str', 'list'])
+    check_parameter('_make_wavecal_image', 'arc_files', 
+                    arc_files, ['str', 'list'])
 
-    check_parameter('_make_wavecal_image', 'sky_files', sky_files, 
-                    ['str', 'list', 'NoneType'])
+    check_parameter('_make_wavecal_image', 'sky_files', 
+                    sky_files, ['str', 'list', 'NoneType'])
 
     check_parameter('_make_wavecal_image', 'linearity_correction',
                     linearity_correction, 'bool')
 
-    check_parameter('_make_wavecal_image', 'detector_info', detector_info,
-                    ['dict', 'NoneType'])
+    check_parameter('_make_wavecal_image', 'detector_info', 
+                    detector_info, ['dict', 'NoneType'])
 
-    check_parameter('_make_wavecal_image', 'flat_file', flat_file, 'str')
+    check_parameter('_make_wavecal_image', 'flat_file', 
+                    flat_file, 'str')
 
-    check_parameter('_make_wavecal_image', 'qa_plotnumber', qa_plotnumber, 
-                    'int')
+    check_parameter('_make_wavecal_image', 'qa_plotnumber', 
+                    qa_plotnumber, 'int')
 
-    check_parameter('_make_wavecal_image', 'qa_figuresize', qa_figuresize, 
-                    'tuple')
+    check_parameter('_make_wavecal_image', 'qa_figuresize', 
+                    qa_figuresize, 'tuple')
 
-    check_parameter('_make_wavecal_image', 'qa_fontsize', qa_fontsize, 
-                    'int')
+    check_parameter('_make_wavecal_image', 'qa_fontsize', 
+                    qa_fontsize, 'int')
 
-    check_parameter('_make_wavecal_image', 'verbose', verbose, 
-                    ['NoneType','bool'])
+    check_parameter('_make_wavecal_image', 'verbose', 
+                    verbose, ['NoneType','bool'])
 
-    check_parameter('_make_wavecal_image', 'qa_show', qa_show, 
-                    ['NoneType','bool'])
+    check_parameter('_make_wavecal_image', 'qa_show', 
+                    qa_show, ['NoneType','bool'])
 
-    check_parameter('_make_wavecal_image', 'qa_showscale', qa_showscale,
-                    ['NoneType','float','int'])
+    check_parameter('_make_wavecal_image', 'qa_showscale', 
+                    qa_showscale, ['NoneType','float','int'])
     
-    check_parameter('_make_wavecal_image', 'qa_showblock', qa_showblock,
-                    ['NoneType','bool'])
+    check_parameter('_make_wavecal_image', 'qa_showblock', 
+                    qa_showblock, ['NoneType','bool'])
         
-    check_parameter('_make_wavecal_image', 'qa_write', qa_write, 
-                    ['NoneType','bool'])
+    check_parameter('_make_wavecal_image', 'qa_write', 
+                    qa_write, ['NoneType','bool'])
 
     check_qakeywords(verbose=verbose)
     
@@ -684,20 +707,21 @@ def _make_wavecal_image(arc_files:str | list,
 
     logging.info(' Creating the arc image.')    
 
-    result = instr.read_fits(arc_files,
-                             setup.state['linearity_info'],
-                             pair_subtract=False,
-                             keywords=setup.state['extract_keywords'],
-                             rotate=flatinfo['rotation'],
-                             linearity_correction=linearity_correction,
-                             extra=detector_info,
-                             verbose=False)
+    result = instr.read_fits(
+        arc_files,
+        setup.state['linearity_info'],
+        pair_subtract=False,
+        keywords=setup.state['extract_keywords'],
+        rotate=flatinfo['rotation'],
+        linearity_correction=linearity_correction,
+        extra=detector_info,
+        verbose=False)
     
     imgs = result[0]
     masks = result[3]
 
     #
-    # Combine images as necessary and don't worry about the variance
+    # Combine images as necessary and don't worry about using the variance
     #
 
     if np.ndim(imgs) == 3:
@@ -730,15 +754,18 @@ def _make_wavecal_image(arc_files:str | list,
     if len(wavecalinfo['skyorders']) !=0:
 
         logging.info(' Creating the sky image.')
-        
+        dosky = True
+
         # Load the image(s)
 
-        result = instr.read_fits(sky_files,
-                                 setup.state['linearity_info'],
-                                 pair_subtract=False,
-                                 keywords=setup.state['extract_keywords'],
-                                 rotate=flatinfo['rotation'],
-                                 verbose=verbose)
+        result = instr.read_fits(
+            sky_files,
+            setup.state['linearity_info'],
+            pair_subtract=False,
+            keywords=setup.state['extract_keywords'],
+            rotate=flatinfo['rotation'],
+            verbose=verbose)
+
         imgs = result[0]
         masks = result[3]
         
@@ -767,20 +794,22 @@ def _make_wavecal_image(arc_files:str | list,
             
         # Mix the orders
 
-        result = wavecal.mix_orders(arc,
-                                    arc_mask,
-                                    sky,
-                                    sky_mask,
-                                    flatinfo['ordermask'],
-                                    flatinfo['orders'],
-                                    wavecalinfo['arcorders'],
-                                    wavecalinfo['skyorders'])
+        result = wavecal.mix_orders(
+            arc,
+            arc_mask,
+            sky,
+            sky_mask,
+            flatinfo['ordermask'],
+            flatinfo['orders'],
+            wavecalinfo['arcorders'],
+            wavecalinfo['skyorders'])
         
         wavecal_image = result[0]
         wavecal_mask = result[1]
 
     else:
         
+        dosky = False
         wavecal_image = arc
         wavecal_mask = arc_mask
 
@@ -788,34 +817,98 @@ def _make_wavecal_image(arc_files:str | list,
     # Do the QA plot
     #
 
-    orders_plotinfo = {'edgecoeffs': flatinfo['edgecoeffs'],
-                       'xranges': flatinfo['xranges'],
-                       'orders': flatinfo['orders']}
-        
-    if qa_write is True:
+    # Get the order information dictionary ready
 
+    orders_plotinfo = {
+        'edgecoeffs': flatinfo['edgecoeffs'],
+        'xranges': flatinfo['xranges'],
+        'orders': flatinfo['orders'],
+        'idl_unrotate':0}
+
+    # Did we use a sky frame?  THe show both arc and sky.
+
+    if dosky is True:
+
+        if qa_write is True:
+        
+            filename = extract.load['wavecal']['output_filename'] + \
+                '_arc'+setup.state['qa_extension']
+            fullpath = os.path.join(setup.state['qa_path'],filename)
+            
+            plot_image(
+                arc,
+                mask=arc_mask,
+                orders_plotinfo=orders_plotinfo,
+                figure_size=qa_figuresize,
+                font_size=qa_fontsize,
+            output_fullpath=fullpath)
+            
+        if qa_show is True:
+                
+            plot_image(
+                arc,
+                mask=arc_mask,
+                plot_number=qa_plotnumber,
+                orders_plotinfo=orders_plotinfo,
+                figure_size=qa_figuresize,
+                font_size=qa_fontsize,
+                showscale=qa_showscale,
+                showblock=qa_showblock)
+
+        if qa_write is True:
+        
+            filename = extract.load['wavecal']['output_filename'] + \
+                '_sky'+setup.state['qa_extension']
+            fullpath = os.path.join(setup.state['qa_path'],filename)
+            
+            plot_image(
+                sky,
+                mask=sky_mask,
+                orders_plotinfo=orders_plotinfo,
+                figure_size=qa_figuresize,
+                font_size=qa_fontsize,
+            output_fullpath=fullpath)
+            
+        if qa_show is True:
+                
+            plot_image(
+                sky,
+                mask=sky_mask,
+                plot_number=qa_plotnumber,
+                orders_plotinfo=orders_plotinfo,
+                figure_size=qa_figuresize,
+                font_size=qa_fontsize,
+                showscale=qa_showscale,
+                showblock=qa_showblock)
+
+    # No matter what, show the wavecal image
+
+    if qa_write is True:
+        
         filename = extract.load['wavecal']['output_filename'] + \
             '_image'+setup.state['qa_extension']
         fullpath = os.path.join(setup.state['qa_path'],filename)
         
-        plot_image(wavecal_image,
-                   mask=wavecal_mask,
-                   orders_plotinfo=orders_plotinfo,
-                   figure_size=qa_figuresize,
-                   font_size=qa_fontsize,
-                   output_fullpath=fullpath)
+        plot_image(
+            wavecal_image,
+            mask=wavecal_mask,
+            orders_plotinfo=orders_plotinfo,
+            figure_size=qa_figuresize,
+            font_size=qa_fontsize,
+            output_fullpath=fullpath)
         
     if qa_show is True:
-        
-        plot_image(wavecal_image,
-                   mask=wavecal_mask,
-                   plot_number=qa_plotnumber,
-                   orders_plotinfo=orders_plotinfo,
-                   figure_size=qa_figuresize,
-                   font_size=qa_fontsize,
-                   showscale=qa_showscale,
-                   showblock=qa_showblock)
-
+            
+        plot_image(
+            wavecal_image,
+            mask=wavecal_mask,
+            plot_number=qa_plotnumber,
+            orders_plotinfo=orders_plotinfo,
+            figure_size=qa_figuresize,
+            font_size=qa_fontsize,
+            showscale=qa_showscale,
+            showblock=qa_showblock)
+                
     #
     # Return the arrays
     #

--- a/src/pyspextool/io/check.py
+++ b/src/pyspextool/io/check.py
@@ -142,15 +142,16 @@ def check_file(files:str,
         return files
 
 
-def check_parameter(caller_name:str,
-                    parameter_name:str,
-                    parameter,
-                    types,
-                    *dimens,
-                    possible_values=None,
-                    list_types=None,
-                    ndarray_size=None,
-                    ndarray_dtype=None):
+def check_parameter(
+    caller_name:str,
+    parameter_name:str,
+    parameter,
+    types,
+    *dimens,
+    possible_values=None,
+    list_types=None,
+    ndarray_size=None,
+    ndarray_dtype=None):
 
     """
     Checks input parameters for a variety of characterisitcs.

--- a/src/pyspextool/plot/plot_image.py
+++ b/src/pyspextool/plot/plot_image.py
@@ -4,22 +4,24 @@ import matplotlib.pyplot as pl
 from matplotlib import rc
 from matplotlib.ticker import AutoMinorLocator
 
+from pyspextool.utils.arrays import idl_plotunrotate
 from pyspextool.fit.polyfit import poly_1d
 from pyspextool.io.check import check_parameter
 from pyspextool.plot.limits import get_image_range
 
-def plot_image(image:npt.ArrayLike,
-               zrange:str | list | float=None,
-               mask:npt.ArrayLike=None,
-               orders_plotinfo:dict=None,
-               trace_plotinfo:dict=None,
-               locateorders_plotinfo:dict=None,
-               figure_size:tuple=(7,7),
-               font_size:int=12,               
-               output_fullpath:str=None,
-               showblock:bool=False,
-               showscale:float | int=1.0,
-               plot_number:int=None):
+def plot_image(
+    image:npt.ArrayLike,
+    zrange:str | list | float=None,
+    mask:npt.ArrayLike=None,
+    orders_plotinfo:dict=None,
+    trace_plotinfo:dict=None,
+    locateorders_plotinfo:dict=None,
+    figure_size:tuple=(7,7),
+    font_size:int=12,               
+    output_fullpath:str=None,
+    showblock:bool=False,
+    showscale:float | int=1.0,
+    plot_number:int=None):
     
     """
     To plot a spectral image along with the edges and order numbers
@@ -57,6 +59,11 @@ def plot_image(image:npt.ArrayLike,
         'orders' : list of int
             (norders,) int array of the order numbers.  By Spextool convention, 
             orders[0] is the order closest to the bottom of the array.
+
+        'idl_unrotate' : int
+            If `image` is a raw image, then the order edgecoefficients may not
+            have been determined at the same IDL rotation value.  If given, 
+            the orders are unrotated by `idl_unrotate`.
 
     trace_plotinfo : dict, optional
         'x' : list
@@ -125,28 +132,32 @@ def plot_image(image:npt.ArrayLike,
     # Check parameters
     #
 
-    check_parameter('plot_image', 'image', image, 'ndarray', 2)
+    check_parameter('plot_image', 'image', 
+                    image, 'ndarray', 2)
 
-    check_parameter('plot_image', 'mask', mask, ['NoneType', 'ndarray'], 2)
+    check_parameter('plot_image', 'mask', 
+                    mask, ['NoneType', 'ndarray'], 2)
 
     check_parameter('plot_image', 'locateorders_plotinfo',
                     locateorders_plotinfo, ['NoneType', 'dict'])
 
-    check_parameter('plot_image', 'orders_plotinfo', orders_plotinfo,
-                    ['NoneType', 'dict'])
+    check_parameter('plot_image', 'orders_plotinfo', 
+                    orders_plotinfo, ['NoneType', 'dict'])
 
-    check_parameter('plot_image', 'trace_plotinfo', trace_plotinfo,
-                    ['NoneType', 'dict'])
+    check_parameter('plot_image', 'trace_plotinfo', 
+                    trace_plotinfo, ['NoneType', 'dict'])
 
-    check_parameter('plot_image', 'output_fullpath', output_fullpath,
-                    ['NoneType', 'str'])
+    check_parameter('plot_image', 'output_fullpath', 
+                    output_fullpath, ['NoneType', 'str'])
 
-    check_parameter('plot_image', 'plot_number', plot_number,
-                    ['NoneType', 'int'])
+    check_parameter('plot_image', 'plot_number', 
+                    plot_number, ['NoneType', 'int'])
 
-    check_parameter('plot_image', 'showblock', showblock, 'bool')
+    check_parameter('plot_image', 'showblock', 
+                    showblock, 'bool')
 
-    check_parameter('plot_image', 'showscale', showscale, ['int','float'])
+    check_parameter('plot_image', 'showscale', 
+                    showscale, ['int','float'])
 
     
     #
@@ -191,21 +202,23 @@ def plot_image(image:npt.ArrayLike,
 
         
     
-def doplot(plot_number:int,
-           figure_size:tuple,
-           font_size:float | int,
-           image:npt.ArrayLike,
-           zrange=None,
-           mask:npt.ArrayLike=None,
-           locateorders_plotinfo:dict=None,
-           orders_plotinfo:dict=None,
-           trace_plotinfo:dict=None):
+def doplot(
+    plot_number:int,
+    figure_size:tuple,
+    font_size:float | int,
+    image:npt.ArrayLike,
+    zrange=None,
+    mask:npt.ArrayLike=None,
+    locateorders_plotinfo:dict=None,
+    orders_plotinfo:dict=None,
+    trace_plotinfo:dict=None):
 
     """
     To plot the image "independent of the device"
 
 
     """
+    img_size = np.shape(image)
 
     # Set the fonts
 
@@ -227,7 +240,7 @@ def doplot(plot_number:int,
         
     else:
 
-        type = 'zscale' if zrange == None else zrange
+        type = 'zscale' if zrange is None else zrange
 
         minmax = get_image_range(image, type)
         if minmax[0] > minmax[1]:
@@ -277,9 +290,20 @@ def doplot(plot_number:int,
         norders = len(orders)
 
         for i in range(norders):
+
+
             x = np.arange(xranges[i, 0], xranges[i, 1] + 1)
             bot = poly_1d(x, edgecoeffs[i, 0, :])
             top = poly_1d(x, edgecoeffs[i, 1, :])
+
+            x, bot = idl_plotunrotate(
+                x,bot,[0,img_size[1]],[0,img_size[0]],
+                orders_plotinfo['idl_unrotate'])
+
+            x = np.arange(xranges[i, 0], xranges[i, 1] + 1)
+            x, top = idl_plotunrotate(
+                x,top,[0,img_size[1]],[0,img_size[0]],
+                orders_plotinfo['idl_unrotate'])
 
             pl.plot(x, bot, color='purple')
             pl.plot(x, top, color='purple')

--- a/src/pyspextool/setup_utils.py
+++ b/src/pyspextool/setup_utils.py
@@ -51,7 +51,7 @@ def pyspextool_setup(
     cal_path:str=None,
     proc_path:str=None,
     qa_path:str=None,
-    search_extension:str=setup.state["search_extensions"][0],
+    input_suffix:str=setup.state["input_suffixes"][0],
     verbose:bool=True,
     qa_show:bool=False,
     qa_showscale:float=1.0,
@@ -84,7 +84,7 @@ def pyspextool_setup(
         If qa_write is True, this is the path where the files will be written.
         Default: current working directory
 
-    search_extension : setup.state['search_extensions']
+    input_suffix : setup.state['input_suffixes']
         The file extension used to search for files in `raw_path`.
     
     verbose : bool, default True
@@ -161,8 +161,8 @@ def pyspextool_setup(
     check_parameter('pyspextool_setup', 'qa_path', qa_path, 
                     ['NoneType', 'str'])
 
-    check_parameter('pyspextool_setup', 'search_extension', search_extension, 
-                    'str', possible_values=setup.state['search_extensions'])
+    check_parameter('pyspextool_setup', 'input_suffix', input_suffix, 
+                    'str', possible_values=setup.state['input_suffixes'])
 
     check_parameter('pyspextool_setup', 'qa_show', qa_show, 'bool')
 
@@ -188,7 +188,7 @@ def pyspextool_setup(
     # Store the search extension
     #
 
-    setup.state['search_extension'] = search_extension
+    setup.state['input_suffix'] = input_suffix
 
     #
     # Set up verbose scale and logging

--- a/src/pyspextool/utils/arrays.py
+++ b/src/pyspextool/utils/arrays.py
@@ -354,6 +354,72 @@ def trim_nan(
         return z
 
 
+def idl_plotunrotate(
+    x:npt.ArrayLike,
+    y:npt.ArrayLike, 
+    xrange:npt.ArrayLike,
+    yrange:npt.ArrayLike, 
+    direction:int):
+
+    """
+    Unrotates and/or tranposes a x and y array (rotate is in multiples of 90deg)
+
+    Input Parameters
+    ----------------
+    img : ndarray
+        an image
+
+    direction : int
+
+        Direction  Transpose?  Rotation Counterclockwise
+        -------------------------------------------------
+
+        0          No          None
+        1          No          90 deg
+        2          No          180 deg
+        3          No          270 deg
+        4          Yes         None
+        5          Yes         90 deg
+        6          Yes         180 deg
+        7          Yes         270 deg
+
+        The directions follow the IDL rotate function convention.
+
+
+    Returns
+    --------
+    ndarray, ndarray
+        The unrotated/untransposed x and y arrays.
+
+    Notes
+    -----
+    Compete set when motivated to do so.
+
+    """
+
+    if direction == 0:
+
+        return x, y
+
+#    if direction == 1:
+#
+#        return y, np.flip(x)-min(x)
+#
+#    if direction == 2:
+#
+#        return x, np.flip(y)+min(y)
+#
+#    if direction == 3:
+#
+#        return y+min(y), np.flip(x)
+
+    if direction == 7:
+
+        return x, yrange[1]-y
+
+
+
+
 def idl_rotate(
     img:npt.ArrayLike, 
     direction:int):


### PR DESCRIPTION
Issue 303:  If the reduction is LXD, then in addition to the merged wave cal file containing arc and sky lines having a QA plot, the individual arc and sky frame also now have QA files.

Issue 342:  The order location purple is now rotated properly in the QA plot after a user combines images before extraction.  

start of issue 236:  Rewrote the code so that the rectification of uspex SXD data is 5x faster (20 sec versus 100 sec) and added a user keyword in ps.extract.extract and ps.extract.load_image called rectification_method.  The default is cubic, but for super fast (but perhaps not as good, still TBD) reductions (going down another 5x) set to 'linear.'.